### PR TITLE
add version callout

### DIFF
--- a/docs/basecamp/install-and-load-a-module-in-logos-basecamp.md
+++ b/docs/basecamp/install-and-load-a-module-in-logos-basecamp.md
@@ -17,6 +17,10 @@ import YouTube from '@site/src/components/YouTube';
 
 #### Access features and functionalities through modules in Logos Basecamp.
 
+:::tip[Version]
+This document is accurate for **Testnet v0.2.1**.
+:::
+
 In Logos [Basecamp](../get-started/glossary.md#basecamp), you can install and load modules that provide features like chat, storage, or wallets from the online [catalogue](../get-started/glossary.md#catalogue) or local `.lgx` files.
 
 There are two types of modules in Logos Basecamp. [Core modules](../get-started/glossary.md#core-module) are the headless background services that provide capabilities like messaging or storage, while [UI modules](../get-started/glossary.md#ui-module) are the visual front-ends users interact with.

--- a/docs/basecamp/install-logos-basecamp.md
+++ b/docs/basecamp/install-logos-basecamp.md
@@ -17,6 +17,10 @@ import YouTube from '@site/src/components/YouTube';
 
 #### Get Logos Basecamp running on your desktop.
 
+:::tip[Version]
+This document is accurate for **Testnet v0.2.1**.
+:::
+
 Logos [Basecamp](../get-started/glossary.md#basecamp) is the desktop shell for Logos. You can discover, install, and run Logos [modules](../get-started/glossary.md#module) and apps using its graphical interface as an alternative to the command line.
 
 You can install Logos Basecamp in two ways:

--- a/docs/basecamp/swap-eth-and-lez-tokens-in-logos-basecamp.md
+++ b/docs/basecamp/swap-eth-and-lez-tokens-in-logos-basecamp.md
@@ -15,6 +15,10 @@ sidebar_position: 3
 
 #### Install the atomic swap app from a catalogue URL and trade Sepolia ETH for LEZ testnet tokens with a counterparty you never have to trust.
 
+:::tip[Version]
+This document is accurate for **Testnet v0.2.1**.
+:::
+
 The atomic swap app is a Logos [Basecamp](../get-started/glossary.md#basecamp) app that trades tokens across two unrelated chains without an exchange, a bridge, or an escrow agent. This procedure takes you from a fresh Basecamp install to a completed swap against a live counterparty that Logos operates, ending with a receipt you can check on both chains' block explorers.
 
 You install this app from a [catalogue](../get-started/glossary.md#catalogue) URL rather than building it. There's no repository to clone, no Nix, and no local chain. Version `0.4.3` also sets up both of your accounts inside the app: a guided **Setup** tab generates your Ethereum key, then creates, initialises, and funds your [LEZ](../get-started/glossary.md#lez) [account](../get-started/glossary.md#account) in [Step 2](#step-2-set-up-your-accounts). Nothing in this journey needs a command line.

--- a/docs/blockchain/blend/join-the-blend-network-as-a-core-node.md
+++ b/docs/blockchain/blend/join-the-blend-network-as-a-core-node.md
@@ -15,6 +15,10 @@ sidebar_position: 1
 
 #### Connect your blockchain node to Blend to contribute to proposer privacy.
 
+:::tip[Version]
+This document is accurate for **Testnet v0.2.1**.
+:::
+
 Joining the [Blend Network](../../get-started/glossary.md#blend-network) lets your blockchain node contribute to the privacy of [Logos Blockchain](../../get-started/glossary.md#logos-blockchain) proposers and receive rewards for participating. This procedure applies to operators of a running Logos Blockchain node who want to register that node as a Blend [core node](../../get-started/glossary.md#core-node). Before you start, make sure your node's address is publicly reachable so other peers can connect to it.
 
 :::note

--- a/docs/blockchain/get-started/run-a-logos-blockchain-node-from-basecamp.md
+++ b/docs/blockchain/get-started/run-a-logos-blockchain-node-from-basecamp.md
@@ -15,6 +15,10 @@ sidebar_position: 2
 
 #### Install the blockchain modules and run a syncing testnet node from the Basecamp desktop app.
 
+:::tip[Version]
+This document is accurate for **Testnet v0.2.1**.
+:::
+
 The [Logos Blockchain](../../get-started/glossary.md#logos-blockchain) is the blockchain [module](../../get-started/glossary.md#module) of the Logos technology stack. You can run a node [from the CLI](./run-a-logos-blockchain-node-from-cli.md), from a [standalone application](../node-app/build-and-run-logos-blockchain-node-app-ui.md), or — as described here — from [**Basecamp**](../../get-started/glossary.md#basecamp), the modular Logos desktop app, by installing the blockchain module and its UI.
 
 :::info[Prerequisites]

--- a/docs/blockchain/get-started/run-a-logos-blockchain-node-from-cli.md
+++ b/docs/blockchain/get-started/run-a-logos-blockchain-node-from-cli.md
@@ -15,6 +15,10 @@ sidebar_position: 3
 
 #### Start a node and verify runtime and consensus signals.
 
+:::tip[Version]
+This document is accurate for **Testnet v0.2.1**.
+:::
+
 With this tutorial, you will install the [Logos Blockchain](../../get-started/glossary.md#logos-blockchain) node, connect to the public testnet, and verify that your node is running. The Logos Blockchain is the blockchain component of the Logos technology stack, providing a privacy-preserving and censorship-resistant framework for decentralised applications. This procedure is for node operators setting up a node for the first time.
 
 :::info[Prerequisites]

--- a/docs/blockchain/node-app/bridge-assets-from-logos-blockchain-to-zone-using-app.md
+++ b/docs/blockchain/node-app/bridge-assets-from-logos-blockchain-to-zone-using-app.md
@@ -15,6 +15,10 @@ sidebar_position: 3
 
 #### Get started locking wallet notes into a Logos Zone, including the LEZ, using the Logos Blockchain UI app.
 
+:::tip[Version]
+This document is accurate for **Testnet v0.2.1**.
+:::
+
 This procedure covers how to lock one or more of your wallet [notes](../../get-started/glossary.md#note) (UTXOs) into a Logos [Zone](../../get-started/glossary.md#zone) (such as the [LEZ](../../get-started/glossary.md#lez)) using the [Logos Blockchain desktop app](./build-and-run-logos-blockchain-node-app-ui.md), and receive the resulting transaction hash. It is intended for wallet users on testnet v0.2 who need to fund a [channel](../../get-started/glossary.md#channel) for off-chain or on-chain channel operations without hand-assembling note IDs, keys, and fees on a CLI.
 
 :::info[Prerequisites]

--- a/docs/blockchain/node-app/build-and-run-logos-blockchain-node-app-ui.md
+++ b/docs/blockchain/node-app/build-and-run-logos-blockchain-node-app-ui.md
@@ -15,6 +15,10 @@ sidebar_position: 1
 
 #### Run a node that participates in consensus via a standalone application.
 
+:::tip[Version]
+This document is accurate for **Testnet v0.2.1**.
+:::
+
 The [Logos Blockchain](../../get-started/glossary.md#logos-blockchain) is the blockchain [module](../../get-started/glossary.md#module) of the Logos technology stack, providing a privacy-preserving and censorship-resistant framework for decentralised network states. You can run a Logos Blockchain node [using the CLI](../get-started/run-a-logos-blockchain-node-from-cli.md) or a standalone application.
 
 :::info[Prerequisites]

--- a/docs/blockchain/node-app/claim-leader-rewards-in-logos-blockchain-ui-app.md
+++ b/docs/blockchain/node-app/claim-leader-rewards-in-logos-blockchain-ui-app.md
@@ -15,6 +15,10 @@ sidebar_position: 4
 
 #### Learn how to get rewarded for having your Logos Blockchain node propose blocks
 
+:::tip[Version]
+This document is accurate for **Testnet v0.2.1**.
+:::
+
 This procedure covers how to claim rewards for participating in the consensus protocol of the [Logos Blockchain](../../get-started/glossary.md#logos-blockchain). It is intended for node operators running their node via the Blockchain UI app.
 
 :::info[Prerequisites]

--- a/docs/blockchain/node-app/move-assets-using-logos-blockchain-app.md
+++ b/docs/blockchain/node-app/move-assets-using-logos-blockchain-app.md
@@ -15,6 +15,10 @@ sidebar_position: 2
 
 #### Get started with token transfers between wallet accounts directly from the dashboard UI.
 
+:::tip[Version]
+This document is accurate for **Testnet v0.2.1**.
+:::
+
 This procedure covers how to send funds from one of your wallet addresses to a recipient on the [Logos Blockchain](../../get-started/glossary.md#logos-blockchain) using the Logos Blockchain dashboard. It is intended for users who need to move tokens between accounts without using the CLI or crafting transactions manually.
 
 :::info[Prerequisites]

--- a/docs/blockchain/zone-sdk/bridge-assets-between-blockchain-and-zone.md
+++ b/docs/blockchain/zone-sdk/bridge-assets-between-blockchain-and-zone.md
@@ -15,6 +15,10 @@ sidebar_position: 2
 
 #### Move tokens between Logos Blockchain and a Zone using channels and the Zone SDK.
 
+:::tip[Version]
+This document is accurate for **Testnet v0.2.1**.
+:::
+
 [Logos Zones](../concepts/about-zones.md) are customizable, high-performance blockchains for applications built on Logos. [Logos Blockchain](../../get-started/glossary.md#logos-blockchain) [notes](../../get-started/glossary.md#note) can be bridged from [Bedrock](../concepts/about-bedrock.md) to Zones, with the Zone's associated [channel](../../get-started/glossary.md#channel) maintaining a token balance that keeps track of the total token value stored in the Zone. 
 
 This procedure covers creating a channel, depositing notes from the Blockchain into a Zone, and withdrawing notes from a Zone back to the Blockchain, using the [Zone SDK](../../get-started/glossary.md#zone-sdk)'s `ZoneSequencer`. It applies to Zone developers building sequencers and indexers; the Zone itself defines how the channel balance maps to its internal accounts, while the SDK only surfaces the on-chain events.

--- a/docs/blockchain/zone-sdk/inscribe-data-on-chain-using-zone-sdk.md
+++ b/docs/blockchain/zone-sdk/inscribe-data-on-chain-using-zone-sdk.md
@@ -17,6 +17,10 @@ sidebar_position: 1
 
 #### Learn how to write plain text as on-chain inscriptions using a simple Logos Zone.
 
+:::tip[Version]
+This document is accurate for **Testnet v0.2.1**.
+:::
+
 Applications built on Logos are implemented in execution environments known as [_Zones_](../concepts/about-zones.md), which post data _inscriptions_ on-chain via Logos channels. A Zone could host a versatile rollup with thousands of applications, such as the [Logos Execution Zone](../../lez/introduction-to-the-logos-execution-zone.md), or it could be a simple, standalone Zone tracking the state of just one application.
 
 The [**Zone SDK**](../../get-started/glossary.md#zone-sdk) is a ready-to-use toolbox that handles basic interactions with a Logos Zone. This tutorial shows how to create a simple Logos Zone that writes plain text as on-chain inscriptions, based on the [TUI Zone demo](https://github.com/logos-blockchain/logos-blockchain/tree/master/deployment/tui-zone).

--- a/docs/blockchain/zone-sdk/operate-decentralised-zone-with-round-robin-sequencer-rotation.md
+++ b/docs/blockchain/zone-sdk/operate-decentralised-zone-with-round-robin-sequencer-rotation.md
@@ -15,6 +15,10 @@ sidebar_position: 3
 
 #### Get started with multi-sequencer channels using the Zone SDK and round-robin slot windows.
 
+:::tip[Version]
+This document is accurate for **Testnet v0.2.1**.
+:::
+
 This tutorial covers how to configure and operate a [Logos Blockchain](../../get-started/glossary.md#logos-blockchain) [channel](../../get-started/glossary.md#channel) with a committee of accredited sequencers that take turns publishing inscriptions to a Logos [Zone](../../get-started/glossary.md#zone). It is intended for zone developers using the [Zone SDK](https://github.com/logos-blockchain/logos-blockchain/tree/master/zone-sdk) who need to move from a single-sequencer setup to a decentralized one.
 
 The Zone SDK currently supports **round-robin** rotation only. Each sequencer publishes inscriptions for `posting_timeframe` slots before the rotation advances to the next sequencer in the `accredited_keys` list. Other scheduling schemes (such as First-Write-Wins) are not yet available.

--- a/docs/build-an-app/tutorials/build-dapp-with-logos-zone-sdk.md
+++ b/docs/build-an-app/tutorials/build-dapp-with-logos-zone-sdk.md
@@ -14,6 +14,10 @@ slug: build-dapp-with-logos-zone-sdk
 
 #### Learn how to use the Zone SDK to implement a decentralised password manager application.
 
+:::tip[Version]
+This document is accurate for **Testnet v0.2.0**.
+:::
+
 This tutorial covers building a Logos [Zone](../../get-started/glossary.md#zone) from scratch using the [Zone SDK](../../get-started/glossary.md#zone-sdk). Zones are execution environments built on the [Logos Blockchain](../../get-started/glossary.md#logos-blockchain) that post data as on-chain inscriptions via Logos channels. A Zone can host a versatile rollup with thousands of applications, such as the [Logos Execution Zone](../../lez/introduction-to-the-logos-execution-zone.md), or a simple standalone Zone tracking the state of a single application.
 
 The Zone SDK provides a ready-to-use toolbox for basic interactions with a Logos Zone. Every Zone is operated by one or more **sequencers**, which collect transactions, batch them, and publish them as inscriptions on the Logos Blockchain. **Indexers** are nodes that follow a Zone's updates on-chain, re-executing them locally to maintain an up-to-date copy of the Zone state. The Zone SDK supports building both.

--- a/docs/build-an-app/tutorials/create-and-use-an-amm-liquidity-pool-on-the-logos-execution-zone.md
+++ b/docs/build-an-app/tutorials/create-and-use-an-amm-liquidity-pool-on-the-logos-execution-zone.md
@@ -14,6 +14,10 @@ slug: create-and-use-an-amm-liquidity-pool-on-the-logos-execution-zone
 
 #### Get started creating a token pair pool, swapping, and managing liquidity on LEZ.
 
+:::tip[Version]
+This document is accurate for **Testnet v0.2.1**.
+:::
+
 This procedure covers the AMM [program](../../get-started/glossary.md#program) on the [Logos Execution Zone](../../get-started/glossary.md#lez), which manages liquidity pools and enables swaps between custom tokens. It walks through creating a liquidity pool for a token pair, swapping tokens, withdrawing liquidity, and adding liquidity back to the pool.
 
 :::note

--- a/docs/core/build-modules/build-a-logos-cpp-ui-module.md
+++ b/docs/core/build-modules/build-a-logos-cpp-ui-module.md
@@ -15,6 +15,10 @@ sidebar_position: 4
 
 #### Get started building a ui\_qml module with a C++ backend that runs in a separate process.
 
+:::tip[Version]
+This document is accurate for **Testnet v0.2.1**.
+:::
+
 This guide covers building a [module](../../get-started/glossary.md#module) that pairs a QML user interface with a C++ backend plugin. The backend runs in a separate `ui-host` process while the QML view loads inside the host app (`logos-basecamp` or `logos-standalone-app`), so a backend crash cannot bring down the host. This guide is intended for developers who have completed [Part 1](wrap-a-c-library-as-a-logos-core-module.md) and want typed, process-isolated inter-module calls from their UI layer.
 
 :::info[Prerequisites]

--- a/docs/core/build-modules/build-and-run-a-logos-core-module.md
+++ b/docs/core/build-modules/build-and-run-a-logos-core-module.md
@@ -15,6 +15,10 @@ sidebar_position: 2
 
 #### Scaffold, build, package, and test a core module on Logos.
 
+:::tip[Version]
+This document is accurate for **Testnet v0.2.1**.
+:::
+
 Logos is a modular application framework built on Qt 6. Applications are composed of dynamically loaded modules (Qt plugins) that provide features and functionality. Logos [core modules](../../get-started/glossary.md#core-module) are non-UI modules that provide backend functionality. Core modules run in isolated `logos_host` processes and communicate via Qt Remote Objects.
 
 :::info[Prerequisites]

--- a/docs/core/build-modules/start-a-logos-module-from-the-cli.md
+++ b/docs/core/build-modules/start-a-logos-module-from-the-cli.md
@@ -15,6 +15,10 @@ sidebar_position: 1
 
 #### Explore how to load and call a Logos module from the command line using `logoscore`.
 
+:::tip[Version]
+This document is accurate for **Testnet v0.2.1**.
+:::
+
 This guide covers how to build and install a Logos [module](../../get-started/glossary.md#module), start the `logoscore` daemon, and call module methods from the command line. It is intended for users who want to run an existing module, or developers who have already built a module binary and want to run it locally for testing or development. By the end you will have a running `logoscore` instance that loads [`accounts_module`](https://github.com/logos-co/logos-accounts-module) as an example module and returns results for mnemonic generation and relative strength.
 
 :::info[Prerequisites]

--- a/docs/core/build-modules/wrap-a-c-library-as-a-logos-core-module.md
+++ b/docs/core/build-modules/wrap-a-c-library-as-a-logos-core-module.md
@@ -15,6 +15,10 @@ sidebar_position: 3
 
 #### Expose functions from a C shared library through a Logos core module.
 
+:::tip[Version]
+This document is accurate for **Testnet v0.2.1**.
+:::
+
 This tutorial walks you through wrapping a C shared library (`.so` on Linux, `.dylib` on macOS) as a Logos [module](../../get-started/glossary.md#module). By the end, you will have a `calc_module` that compiles, loads, and responds to method calls via `logoscore`. You write one plain C++ class — no Qt, no plugin boilerplate — and the build system generates the Qt plugin around it.
 
 For an example used in production, refer to [logos-lib2p2-module](https://github.com/logos-co/logos-libp2p-module) - a module that wraps the `nim-libp2p` library (compiled to a C shared library).

--- a/docs/lez/accounts/set-up-shared-private-lez-account.md
+++ b/docs/lez/accounts/set-up-shared-private-lez-account.md
@@ -15,6 +15,10 @@ sidebar_position: 1
 
 #### Get started with group-owned private accounts where every member independently derives the same keys.
 
+:::tip[Version]
+This document is accurate for **Testnet v0.2.1**.
+:::
+
 This procedure covers how to create a shared [private account](../../get-started/glossary.md#private-account) (regular or [PDA](../../get-started/glossary.md#pda)) on the [LEZ](../../get-started/glossary.md#lez) that is jointly controlled by multiple members. From one 32-byte [Group Master Secret](../../get-started/glossary.md#group-master-secret) ([GMS](../../get-started/glossary.md#gms)), every member independently derives the same [account](../../get-started/glossary.md#account) keys ([NSK](../../get-started/glossary.md#nsk), [VSK](../../get-started/glossary.md#vsk), [NPK](../../get-started/glossary.md#npk), [VPK](../../get-started/glossary.md#vpk)), so any member can view and spend the shared balance without an interactive key exchange at spend time. It is intended for developers on testnet v0.2 who need multi-party custody of a private balance or a private PDA.
 
 This feature is 1-of-n at the key layer: any GMS holder can derive every key and spend the account. Threshold gating must be implemented at the [program](../../get-started/glossary.md#program) layer. View-only membership is not supported — any GMS holder gets both viewing and spending capability.

--- a/docs/lez/follow-chain/run-lez-indexer.md
+++ b/docs/lez/follow-chain/run-lez-indexer.md
@@ -15,6 +15,10 @@ sidebar_position: 1
 
 #### Get started with the LEZ Indexer and query finalized LEZ state over HTTP RPC.
 
+:::tip[Version]
+This document is accurate for **Testnet v0.2.1**.
+:::
+
 The [LEZ](../../get-started/glossary.md#lez) Indexer is a service that reads the finalized LEZ state from the [Logos Blockchain](../../get-started/glossary.md#logos-blockchain) node and exposes it over an HTTP RPC interface. Any application can use this interface to query blocks, transactions, and [account](../../get-started/glossary.md#account) state. This procedure walks you through running an LEZ Indexer locally alongside its dependencies, verifying it is indexing blocks, and querying account state through the RPC.
 
 :::info[Prerequisites]

--- a/docs/lez/follow-chain/start-and-use-instance-of-lez-explorer.md
+++ b/docs/lez/follow-chain/start-and-use-instance-of-lez-explorer.md
@@ -15,6 +15,10 @@ sidebar_position: 2
 
 #### Get a clear view of on-chain activity including blocks, transactions, and accounts.
 
+:::tip[Version]
+This document is accurate for **Testnet v0.2.1**.
+:::
+
 The [LEZ](../../get-started/glossary.md#lez) Explorer lets you inspect the state of the [Logos Execution Zone](../../get-started/glossary.md#logos-execution-zone) in real time. This procedure walks you through starting all required services locally and using the Explorer UI to browse blocks, search transactions, and look up [account](../../get-started/glossary.md#account) balances. It is intended for developers working on testnet v0.2 who want to verify on-chain state or test wallet interactions.
 
 If you don't want to run your own LEZ explorer instance, navigate instead to the [public LEZ explorer](https://explorer.testnet.lez.logos.co/).

--- a/docs/lez/get-started/run-lez-wallet-ui-and-initiate-native-token-transfers.md
+++ b/docs/lez/get-started/run-lez-wallet-ui-and-initiate-native-token-transfers.md
@@ -15,6 +15,10 @@ sidebar_position: 1
 
 #### Use the wallet UI to set up accounts and try every type of native token transfer on the LEZ testnet.
 
+:::tip[Version]
+This document is accurate for **Testnet v0.2.1**.
+:::
+
 The wallet UI is a simple entrypoint for getting started on the [LEZ](../../get-started/glossary.md#lez). This procedure walks you through running the wallet UI on your machine, syncing it with the public LEZ testnet, creating [accounts](../../get-started/glossary.md#account), and executing all combinations of public, private, shielded, and deshielded native token transfers. The LEZ testnet runs the centralised LEZ sequencer, which processes the transactions the wallet UI submits, while the wallet UI itself manages your accounts locally and can execute transfers with any combination of private and public accounts.
 
 :::note

--- a/docs/lez/get-started/run-lez-wallet-via-cli.md
+++ b/docs/lez/get-started/run-lez-wallet-via-cli.md
@@ -15,6 +15,10 @@ sidebar_position: 2
 
 #### Try the wallet CLI against the live LEZ testnet.
 
+:::tip[Version]
+This document is accurate for **Testnet v0.2.1**.
+:::
+
 This procedure explains how to install the wallet CLI from the [LEZ repository](https://github.com/logos-blockchain/logos-execution-zone/) and point it at the public [LEZ](../../get-started/glossary.md#lez) testnet sequencer.
 
 :::info[Prerequisites]

--- a/docs/lez/programs/trade-tokens-on-lez-amm-program.md
+++ b/docs/lez/programs/trade-tokens-on-lez-amm-program.md
@@ -15,6 +15,10 @@ sidebar_position: 2
 
 #### Use the SPEL CLI to deploy an AMM, create a pool, swap tokens, and publish a TWAP price on LEZ testnet v0.2.
 
+:::tip[Version]
+This document is accurate for **Testnet v0.2.1**.
+:::
+
 This procedure explains how developers and node operators deploy and drive the automated market maker (AMM) [program](../../get-started/glossary.md#program) on the [Logos Execution Zone](../../get-started/glossary.md#logos-execution-zone) ([LEZ](../../get-started/glossary.md#lez)), from building the on-chain programs through swapping tokens and publishing a TWAP oracle price, all using the [SPEL CLI](https://github.com/logos-co/spel). The AMM is one of the essential launch-day applications for Logos, since it enables on-chain trading and supplies the price data that on-chain oracles rely on. Follow this procedure on LEZ testnet v0.2 whenever you need to stand up a pool from scratch, execute a swap, or publish a fresh price to the TWAP oracle.
 
 :::info[Prerequisites]

--- a/docs/lez/programs/write-and-deploy-lez-program-with-scaffold.md
+++ b/docs/lez/programs/write-and-deploy-lez-program-with-scaffold.md
@@ -17,6 +17,10 @@ sidebar_position: 1
 
 #### Use `logos-scaffold` to create, build, and deploy a guest program on the Logos Execution Zone testnet.
 
+:::tip[Version]
+This document is accurate for **Testnet v0.2.1**.
+:::
+
 [`logos-scaffold`](https://github.com/logos-co/scaffold) is a project scaffold and CLI tool that manages the full lifecycle of a [LEZ](../../get-started/glossary.md#lez) guest [program](../../get-started/glossary.md#program) — from project creation to deployment. It pins LEZ and SPEL dependencies, builds a project-local sequencer, and handles wallet interactions, so you can focus on writing your program logic.
 
 :::info[Prerequisites]

--- a/docs/lez/transfer-tokens/create-and-transfer-custom-tokens-on-the-logos-execution-zone.md
+++ b/docs/lez/transfer-tokens/create-and-transfer-custom-tokens-on-the-logos-execution-zone.md
@@ -15,6 +15,10 @@ sidebar_position: 2
 
 #### Use the wallet CLI to create custom tokens and transfer them between public and private accounts.
 
+:::tip[Version]
+This document is accurate for **Testnet v0.2.1**.
+:::
+
 The Logos Execution Zone ([LEZ](../../get-started/glossary.md#lez)) is a programmable blockchain that cleanly separates public and private state while keeping them fully interoperable. It's a component of the Logos project. You can use the wallet CLI to invoke LEZ's [token program](../../get-started/glossary.md#token-program) to create and transfer custom tokens between [public and private accounts](transfer-native-tokens-on-the-logos-execution-zone.md) on LEZ.
 
 The token program is a built-in LEZ [program](../../get-started/glossary.md#program) that provides standard token functionality, including defining new token assets and transferring balances. It uses a single shared program rather than requiring a separate contract deployment for each token. The token program is privacy-agnostic. You use the same instructions whether execution is public (on-chain) or privacy-preserving (off-chain with a zero-knowledge proof). The protocol decides the execution mode, and the token logic is unchanged.

--- a/docs/lez/transfer-tokens/transfer-lez-tokens-between-public-private-states.md
+++ b/docs/lez/transfer-tokens/transfer-lez-tokens-between-public-private-states.md
@@ -15,6 +15,10 @@ sidebar_position: 3
 
 #### Get started with private transfers to accounts you don't control, using a recipient-published keypair.
 
+:::tip[Version]
+This document is accurate for **Testnet v0.2.1**.
+:::
+
 This procedure covers how to credit a [private account](../../get-started/glossary.md#private-account) — regular or a [Program Derived Address](../../get-started/glossary.md#program-derived-address) ([PDA](../../get-started/glossary.md#pda)) — that you do not control, using only the recipient's published keypair and the sender's chosen identifier. It is intended for wallet users on testnet v0.2 who need to make private payments without interactive setup or per-sender [account](../../get-started/glossary.md#account) registration. For example, a recipient can publish one keypair and receive from many independent senders, each into a separate account.
 
 :::info[Prerequisites]

--- a/docs/lez/transfer-tokens/transfer-native-tokens-on-the-logos-execution-zone.md
+++ b/docs/lez/transfer-tokens/transfer-native-tokens-on-the-logos-execution-zone.md
@@ -15,6 +15,10 @@ sidebar_position: 1
 
 #### Use the wallet CLI to send native tokens to public and private accounts.
 
+:::tip[Version]
+This document is accurate for **Testnet v0.2.1**.
+:::
+
 The Logos Execution Zone ([LEZ](../../get-started/glossary.md#lez)) is a programmable blockchain that cleanly separates public and private state while keeping them fully interoperable. It's a component of the Logos project. You can use the wallet CLI to invoke LEZ's authenticated-transfers [program](../../get-started/glossary.md#program) to transfer native tokens between public and private accounts.
 
 On LEZ, public and private accounts differ in where their state lives and how transfers update that state.

--- a/docs/messaging/chat-module/build-logos-module-that-uses-chat-module-api.md
+++ b/docs/messaging/chat-module/build-logos-module-that-uses-chat-module-api.md
@@ -15,6 +15,10 @@ sidebar_position: 1
 
 #### Get started with private 1:1 and group end-to-end encrypted messaging in your own Logos module.
 
+:::tip[Version]
+This document is accurate for **Testnet v0.2.1**.
+:::
+
 This procedure covers how to build a Logos [module](../../get-started/glossary.md#module) that calls the [logos-chat-module](https://github.com/logos-co/logos-chat-module) API (tag `v0.2.2`) to exchange addresses, open private 1:1 (or *direct*) and group conversations, and send and receive end-to-end encrypted messages on the Logos network. It is intended for application developers who want to integrate private messaging without taking direct dependencies on `liblogoschat` or `logos-delivery`.
 
 Chat state is **ephemeral** in this release: identity, conversations, and message history live in memory only. Restarting an instance mints a fresh identity (with a new address) and an empty conversation list.

--- a/docs/messaging/delivery/run-logos-delivery-node.md
+++ b/docs/messaging/delivery/run-logos-delivery-node.md
@@ -15,6 +15,10 @@ sidebar_position: 2
 
 #### Use the Logos Delivery module to run a Logos delivery node
 
+:::tip[Version]
+This document is accurate for **Testnet v0.2.1**.
+:::
+
 This procedure covers how to install and start a `logos-delivery-module` node connected to the Logos testnet (v0.2). It is intended for node operators who want to run their own Delivery node and join the network. Three installation paths are available — Docker, prebuilt binaries, and Nix — so you can choose the one that fits your environment.
 
 Choose one of the three installation paths based on your environment:

--- a/docs/messaging/delivery/use-logos-delivery-module-api-from-app.md
+++ b/docs/messaging/delivery/use-logos-delivery-module-api-from-app.md
@@ -15,6 +15,10 @@ sidebar_position: 1
 
 #### Get started integrating Logos messaging into a C++ module.
 
+:::tip[Version]
+This document is accurate for **Testnet v0.2.1**.
+:::
+
 This procedure covers building a Logos [module](../../get-started/glossary.md#module) that calls the [Logos Delivery](../../get-started/glossary.md#logos-delivery) API to subscribe to content topics, send messages, react to delivery events, and exchange messages over a reliable channel. It gives application developers a working pattern for integrating Logos messaging into their C++ modules. A complete, runnable reference implementation is available in [`logos-delivery-demo`](https://github.com/logos-co/logos-delivery-demo/tree/v0.2.0) (tag `v0.2.0`).
 
 The two repositories used in this tutorial are [`logos-delivery-module`](https://github.com/logos-co/logos-delivery-module) (pinned to [`v0.2.0`](https://github.com/logos-co/logos-delivery-module/tree/3258cdb0132e37228aa2519e0c01c0e7429a20dd)) and [`logos-delivery`](https://github.com/logos-messaging/logos-delivery), which is a transitive dependency resolved and linked statically by Nix.

--- a/docs/messaging/get-started/send-1-1-messages-logos-chat.md
+++ b/docs/messaging/get-started/send-1-1-messages-logos-chat.md
@@ -15,6 +15,10 @@ sidebar_position: 2
 
 #### Try out end-to-end encrypted private messaging over the Logos network.
 
+:::tip[Version]
+This document is accurate for **Testnet v0.2.1**.
+:::
+
 This procedure shows how to use the [Logos Chat](../../get-started/glossary.md#logos-chat) app to exchange encrypted 1:1 messages between two running instances. The app is a QML and C++ UI built on top of the [`logos-chat-module`](https://github.com/logos-co/logos-chat-module), which wraps the [Logos Chat SDK](https://github.com/logos-messaging/logos-chat). It demonstrates the basic private-messaging capabilities of the Logos Chat [Module](../../get-started/glossary.md#module): ephemeral identity, intro-bundle handshake, and encrypted messaging with no central server. Use this procedure to verify the setup works or to explore the messaging flow for development purposes.
 
 Identity, conversations, and message history exist only while the app is running. Restarting an instance gives it a new identity and clears all conversations.

--- a/docs/mixnet/get-started/send-anonymised-messages-over-the-mix-network.md
+++ b/docs/mixnet/get-started/send-anonymised-messages-over-the-mix-network.md
@@ -15,6 +15,10 @@ sidebar_position: 1
 
 #### Get started sending and receiving messages with sender anonymity using the Logos Chat UI.
 
+:::tip[Version]
+This document is accurate for **Testnet v0.2.1**.
+:::
+
 This procedure covers how to run the [`chat_ui_mix`](https://github.com/logos-co/logos-chat-ui/tree/feat/logos-testnetv02-mix) desktop app, connect to the testnet-0.2 [mix](../../get-started/glossary.md#mix) fleet, and exchange messages between two instances with sender unlinkability. No configuration is required — the app ships with shared testnet credentials and discovers the fleet automatically.
 
 :::info[Prerequisites]

--- a/docs/peer-discovery/get-started/build-logos-core-module-that-uses-service-discovery-api.md
+++ b/docs/peer-discovery/get-started/build-logos-core-module-that-uses-service-discovery-api.md
@@ -15,6 +15,10 @@ sidebar_position: 5
 
 #### Get started with typed, service-keyed peer lookups in a live Logos network.
 
+:::tip[Version]
+This document is accurate for **Testnet v0.2.1**.
+:::
+
 Applications on the Logos network need a protocol-agnostic way to find peers offering specific services — [mix](../../get-started/glossary.md#mix) nodes, relay nodes, storage providers — at runtime without hard-coding topology or peer lists. The Service Discovery API enables any Logos Core [module](../../get-started/glossary.md#module) to perform typed, service-keyed peer lookups that work from lightweight client nodes that do not participate in DHT routing, unblocking any app that needs to wire itself into a live Logos network service. This procedure covers how to write and run a Logos Core module that calls the `libp2p_module` Service Discovery API to advertise a named service to the network and discover other peers offering that same service.
 
 :::info[Prerequisites]

--- a/docs/run-a-node/get-started/run-logos-node-blockchain-storage-delivery.md
+++ b/docs/run-a-node/get-started/run-logos-node-blockchain-storage-delivery.md
@@ -15,6 +15,10 @@ sidebar_position: 1
 
 #### Get started running a full Logos node with all three core modules on testnet v0.2.1.
 
+:::tip[Version]
+This document is accurate for **Testnet v0.2.1**.
+:::
+
 This procedure covers installing and running a single [Logos node](../../get-started/glossary.md#logos-node) with `logoscore` hosting the `blockchain_module`, `storage_module`, and `delivery_module` from one shared modules directory. It is intended for node operators who want to join the testnet and contribute to the Logos network. The steps assume a Linux host.
 
 The default paths used throughout this procedure are:

--- a/docs/storage/get-started/run-logos-storage-node.md
+++ b/docs/storage/get-started/run-logos-storage-node.md
@@ -17,6 +17,10 @@ sidebar_position: 1
 
 #### Get started running a Logos storage node and uploading your first file to the Logos network.
 
+:::tip[Version]
+This document is accurate for **Testnet v0.2.1**.
+:::
+
 This procedure covers how to build and run the [Logos Storage Module](https://github.com/logos-co/logos-storage-module/), connect it to the testnet bootstrap nodes, publish a file, and verify that the file can be downloaded. It is intended for node operators on testnet v0.2 who want to contribute storage capacity to the Logos network.
 
 :::info[Prerequisites]

--- a/docs/storage/get-started/run-mix-network-of-storage-nodes.md
+++ b/docs/storage/get-started/run-mix-network-of-storage-nodes.md
@@ -18,6 +18,10 @@ sidebar_position: 3
 
 #### Stand up a local Mix network and download a file through it, with the content lookup anonymized.
 
+:::tip[Version]
+This document is accurate for **Testnet v0.2.1**.
+:::
+
 This procedure stands up a small local [Mix](../concepts/mix.md) network using `logoscore`: six [Logos Storage Module](https://github.com/logos-co/logos-storage-module/) nodes on one machine — four Mix relays wired around a bootstrap node, plus two storage nodes that route their DHT lookups through the relays. At the end, one storage node uploads a file and the other downloads it with the lookup tunnelled over Mix.
 
 :::info[Prerequisites]

--- a/docs/storage/get-started/set-up-and-use-logos-storage-ui.md
+++ b/docs/storage/get-started/set-up-and-use-logos-storage-ui.md
@@ -15,6 +15,10 @@ sidebar_position: 2
 
 #### Get started sharing and downloading files on the Logos Storage network
 
+:::tip[Version]
+This document is accurate for **Testnet v0.2.1**.
+:::
+
 The [Logos Storage](../../get-started/glossary.md#logos-storage) UI is a file-sharing application built on top of the [Logos Storage Module](https://github.com/logos-co/logos-storage-module). This guide covers running the application (through Logos [Basecamp](../../get-started/glossary.md#basecamp) or by building it with Nix), configuring your node through the onboarding wizard, and using the UI to share, download, and delete files. It is intended for node operators running the application on Linux or macOS.
 
 ## What to expect

--- a/docs/storage/get-started/troubleshooting.md
+++ b/docs/storage/get-started/troubleshooting.md
@@ -13,6 +13,10 @@ slug: faq
 
 #### Fix the most common connectivity problems of a storage node.
 
+:::tip[Version]
+This document is accurate for **Testnet v0.2.1**.
+:::
+
 [Logos Storage](../../get-started/glossary.md#logos-storage) requires your node to be reachable from the internet and, to that end, you must open two ports on your router:
 
 - **Discovery port**: UDP, defaults to `8090`. Used for discovery and DHT operations.


### PR DESCRIPTION
## Summary
- Cherry-picked from rln-membership (cc56b1f), which has now been reverted on that branch (f0d0aec) since PR #427 is still open.
- Adds a version callout to docs across basecamp, blockchain, lez, messaging, mixnet, peer-discovery, run-a-node, and storage sections.
- One file from the original commit (`docs/lez/rln/register-rln-membership-from-basecamp.md`) was excluded since it doesn't exist on `main` yet (still part of #427).

## Test plan
- [ ] Review rendered callouts in docs preview