### PR TITLE
docs(basecamp): refresh the swap walkthrough against the shipped app

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,27 @@
+# Project agent memory
+
+This file is the project's committed home for project-intrinsic agent knowledge: build, test, release, architecture, and sharp-edge notes that should travel with the code.
+
+## Checks before opening a PR
+
+Two checks run on every PR, and both are cheap to run locally:
+
+- `npm ci && npm run build` — the Docusaurus build (`.github/workflows/build-check.yml`). Catches broken relative links and bad frontmatter.
+- `vale <changed files>` — prose lint (`.github/workflows/vale.yml`). It runs with `filter_mode: added` and `fail_on_error: true`, so **only `error`-level alerts on lines you added block the merge**; warnings and suggestions never do. Compare against the pre-change file rather than chasing every alert.
+
+`Logos.SpellingGB` is a plain en_GB dictionary and rejects ordinary technical words (`tooltip`, `Env`, `swap's`). `Google.EmDash` rejects a spaced em dash. Both stop at inline code, so a literal UI string that trips them belongs in backticks, not bold. Repo-wide vocabulary additions go in `.github/styles/config/vocabularies/Logos/accept.txt`.
+
+## Docs about software living in other repos
+
+Several pages under `docs/` (notably `docs/basecamp/swap-eth-and-lez-tokens-in-logos-basecamp.md`) are literal walkthroughs of apps whose source is in another repository. There is no CI that can detect drift, so every UI string, version, address, and program ID has to be re-verified against that repo's release tags before the page is edited — the app's own QML/source is the authority, not the page's previous wording.
+
+## Conventions
+
+`CONTRIBUTING.md` is the authority on document types, templates, and the review workflow; read it before adding or restructuring a page. Note the repo-wide `:::tip[Version]` banner that states which Testnet release a page is accurate for — it tracks the Testnet, not the app the page describes.
+
+## Maintaining this file
+
+Keep this file for knowledge useful to almost every future agent session in this project.
+Do not repeat what the codebase already shows; point to the authoritative file or command instead.
+Prefer rewriting or pruning existing entries over appending new ones.
+When updating this file, preserve this bar for all agents and keep entries concise.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,2 @@
+<!-- Points Claude at AGENTS.md via import; edit AGENTS.md, not this file. -->
+@AGENTS.md

--- a/docs/basecamp/swap-eth-and-lez-tokens-in-logos-basecamp.md
+++ b/docs/basecamp/swap-eth-and-lez-tokens-in-logos-basecamp.md
@@ -53,7 +53,7 @@ The time locks make the failure case safe. Each lock carries a deadline, and you
 
 - [Basecamp installed and running](./install-logos-basecamp.md).
 - Internet access.
-- A small amount of **Sepolia ETH**, sent to the throwaway Ethereum address the app generates for you in [Step 2](#step-2-set-up-your-accounts). The trade itself costs `0.00001` ETH, so roughly `0.01` Sepolia ETH covers it and the gas comfortably. The app funds your LEZ side for you but cannot fund your Ethereum side, so this part is genuinely required: without it the app blocks the swap rather than letting it fail on gas.
+- A small amount of **Sepolia ETH**, sent to the throwaway Ethereum address the app generates for you in [Step 2](#step-2-set-up-your-accounts). The trade itself costs `0.00001` ETH, so roughly `0.01` Sepolia ETH covers it and the gas comfortably. The app funds your LEZ side for you but cannot fund your Ethereum side, so this part is genuinely required: without it you cannot complete a swap.
     - **Setup** offers `https://sepolia-faucet.pk910.de/` for this, and any other [public Sepolia faucet](https://ethereum.org/en/developers/docs/networks/) works too. Most faucets just ask for the destination address, so you don't need a separate wallet app.
 :::
 
@@ -194,7 +194,7 @@ Logos runs a maker on this testnet. It publishes offers and waits for someone to
 
 1. Click the button reading `Accept — buy 10 LEZ`.
 
-    If the button is disabled, the app shows why immediately beneath it, such as `Finish setting up first — open Setup`, `This offer has expired`, or a note that you don't hold enough ETH for this offer plus gas.
+    If the button is disabled, the app shows why immediately beneath it, such as `Finish setting up first — open Setup` or `This offer has expired`.
 
 1. Switch to the **Swap** tab and watch it run.
 

--- a/docs/basecamp/swap-eth-and-lez-tokens-in-logos-basecamp.md
+++ b/docs/basecamp/swap-eth-and-lez-tokens-in-logos-basecamp.md
@@ -136,7 +136,7 @@ The Ethereum key the app generates is a fresh, throwaway key. Fund it with Sepol
 
     This is the one part that has to happen outside the app, because only you can fund your Ethereum address. The section names a faucet, `https://sepolia-faucet.pk910.de/`, behind a **Copy faucet link** button; Basecamp can't open it for you, so paste it into your browser yourself. Any other public Sepolia faucet works just as well.
 
-    **Expected:** while you wait, the section reads `Watching for it… you don't need to do anything.` and polls for the balance on its own. Once the ETH lands it shows `done` and a line reading **Arrived —** followed by the amount.
+    **Expected:** while you wait, the section reads `Watching for it… you don't need to do anything.` and polls for the balance on its own. Once the ETH lands it shows `done` and a line reading `Arrived —` followed by the amount.
 
 1. Under **5. Start trading**, click **Go to Market**.
 

--- a/docs/basecamp/swap-eth-and-lez-tokens-in-logos-basecamp.md
+++ b/docs/basecamp/swap-eth-and-lez-tokens-in-logos-basecamp.md
@@ -21,7 +21,7 @@ This document is accurate for **Testnet v0.2.1**.
 
 The atomic swap app is a Logos [Basecamp](../get-started/glossary.md#basecamp) app that trades tokens across two unrelated chains without an exchange, a bridge, or an escrow agent. This procedure takes you from a fresh Basecamp install to a completed swap against a live counterparty that Logos operates, ending with a receipt you can check on both chains' block explorers.
 
-You install this app from a [catalogue](../get-started/glossary.md#catalogue) URL rather than building it. There's no repository to clone, no Nix, and no local chain. Version `0.4.3` also sets up both of your accounts inside the app: a guided **Setup** tab generates your Ethereum key, then creates, initialises, and funds your [LEZ](../get-started/glossary.md#lez) [account](../get-started/glossary.md#account) in [Step 2](#step-2-set-up-your-accounts). Nothing in this journey needs a command line.
+You install this app from a [catalogue](../get-started/glossary.md#catalogue) URL rather than building it. There's no repository to clone, no Nix, and no local chain. The app also sets up both of your accounts for you: a guided **Setup** tab generates your Ethereum key, then creates, initialises, and funds your [LEZ](../get-started/glossary.md#lez) [account](../get-started/glossary.md#account), and finishes by pointing you at a faucet for the Sepolia gas it can't fetch on your behalf, all in [Step 2](#step-2-set-up-your-accounts). Nothing in this journey needs a command line.
 
 ## Networks and addresses
 
@@ -33,7 +33,7 @@ The app ships with these values already filled in. They're listed here so you ca
 | Ethereum RPC | `wss://ethereum-sepolia-rpc.publicnode.com` |
 | Ethereum HTLC contract, on Sepolia | `0x351B0EA07739FA9F6769213927D7836a790A5FAF` |
 | LEZ sequencer | `https://testnet.lez.logos.co` |
-| LEZ HTLC program | `27720b5b0345135d8e684eb172c27f5fb237548cc891a3ec889d0ed340504070` |
+| LEZ HTLC program | `9eb88f51aae87a58fb74b8d2dc7327b39333585e63280e3f9cf8d86dac0ed702` |
 | Ethereum explorer | `https://sepolia.etherscan.io/tx/<TX_HASH>` |
 | LEZ explorer | `https://explorer.testnet.lez.logos.co/transaction/<TX_HASH>` |
 
@@ -53,14 +53,14 @@ The time locks make the failure case safe. Each lock carries a deadline, and you
 
 - [Basecamp installed and running](./install-logos-basecamp.md).
 - Internet access.
-- A small amount of **Sepolia ETH**, sent to the throwaway Ethereum address the app generates for you in [Step 2](#step-2-set-up-your-accounts). The trade itself costs `0.00001` ETH, so roughly `0.01` Sepolia ETH covers it and the gas comfortably.
-    - You can obtain Sepolia ETH from any [public Sepolia faucet](https://ethereum.org/en/developers/docs/networks/). Most faucets just ask for the destination address, so you don't need a separate wallet app.
+- A small amount of **Sepolia ETH**, sent to the throwaway Ethereum address the app generates for you in [Step 2](#step-2-set-up-your-accounts). The trade itself costs `0.00001` ETH, so roughly `0.01` Sepolia ETH covers it and the gas comfortably. The app funds your LEZ side for you but cannot fund your Ethereum side, so this part is genuinely required: without it the app blocks the swap rather than letting it fail on gas.
+    - **Setup** offers `https://sepolia-faucet.pk910.de/` for this, and any other [public Sepolia faucet](https://ethereum.org/en/developers/docs/networks/) works too. Most faucets just ask for the destination address, so you don't need a separate wallet app.
 :::
 
 ## What to expect
 
 - You can add a third-party catalogue to Basecamp and install an app from it.
-- You can use the app's guided **Setup** tab to generate an Ethereum key and to create, initialise, and fund a LEZ account, with no command line and no hand-copied keys.
+- You can use the app's guided **Setup** tab to generate an Ethereum key, to create, initialise, and fund a LEZ account, and to get that Ethereum key funded, with no command line and no hand-copied keys.
 - You can take a live offer and complete a real cross-chain swap on public test networks.
 - You can verify both legs of your swap independently on two block explorers.
 
@@ -86,7 +86,7 @@ Basecamp arrives with the official Logos catalogue configured, and it merges tha
 
 1. Go back to **Package Manager** and search for `swap`.
 
-    **Expected:** two packages from the new repository, `swap` and `swap_ui`, both shown as **ETH ↔ LEZ Atomic Swap** at version `0.4.3`.
+    **Expected:** two packages from the new repository, `swap` and `swap_ui`, both shown as **ETH ↔ LEZ Atomic Swap** and both at the same version. The catalogue always serves the current release, so take whatever version it offers rather than looking for a particular number.
 
 1. Install `swap` first, then install `swap_ui`.
 
@@ -98,7 +98,7 @@ Basecamp arrives with the official Logos catalogue configured, and it merges tha
 
 1. Restart Basecamp, then open **ETH ↔ LEZ Atomic Swap** from the sidebar.
 
-    **Expected:** a row of seven tabs across the top: **Market**, **Config**, **Maker**, **Taker**, **Refund**, **History**, and **Setup**. Along the top you also get live `ETH` and `LEZ` balances with a **Refresh** button, and a status line that settles on `Delivery connected` once the app finds a peer.
+    **Expected:** a row of six tabs across the top: **Market**, **Swap**, and **History**, then, after a divider, **Sell**, **Refund**, and **Setup**. Beneath the tabs runs a strip with your `ETH` and `LEZ` addresses and balances, which keep themselves up to date, and a connection chip that settles on `Connected` once the app finds a peer, gaining a peer count—`Connected · 1 peer` and up—as it counts them.
 
     On a fresh install, with nothing configured yet, the app opens on the **Setup** tab for you. That's the next step.
 
@@ -108,7 +108,7 @@ The catalogue is saved in your Basecamp settings and survives restarts. You add 
 
 ## Step 2: Set up your accounts
 
-A swap needs two identities: an Ethereum key to sign your Sepolia transactions, and an initialised LEZ account to receive your tokens. Version `0.4.3` builds both for you in the **Setup** tab—no command line, and no copying a raw private key between apps. Every field the tab fills is an ordinary **Config** field underneath, so nothing here is hidden from you.
+A swap needs two identities: an Ethereum key to sign your Sepolia transactions, and an initialised LEZ account to receive your tokens. The app builds both for you in the **Setup** tab—no command line, and no copying a raw private key between apps. Every field the tab fills is an ordinary configuration field underneath, listed in the tab's own **Advanced settings** section, so nothing here is hidden from you.
 
 On a fresh install the app opens on the **Setup** tab automatically. You can also reach it any time from the **Setup** tab at the right-hand end of the tab row.
 
@@ -118,53 +118,59 @@ The Ethereum key the app generates is a fresh, throwaway key. Fund it with Sepol
 
 1. Open the **Setup** tab.
 
-    **Expected:** a page headed **Get set up** with three numbered cards—**1. Ethereum key**, **2. LEZ account**, and **3. Fund it**. Each card's border turns green as you complete it, and a **4. Done** card appears once funding finishes.
+    **Expected:** a page headed **Get set up** with five numbered sections—**1. Ethereum key**, **2. LEZ account**, **3. Fund LEZ**, **4. Get test ETH**, and **5. Start trading**. Each section's border turns green and its heading gains a `done` marker as you complete it. Only the first four ask anything of you; the fifth is the handoff to the market, and it stays dimmed until the ones above it are done.
 
-1. Under **1. Ethereum key**, click **Generate new key**.
+1. Under **1. Ethereum key**, click **Generate a key**.
 
-    **Expected:** the card shows `done` and displays **Address:** followed by a new `0x…` address. The app writes the matching private key straight into **Config** for you; you never see or paste it.
+    **Expected:** the section shows `done` and displays **Your address** followed by a new `0x…` address, with a copy button beside it. The app writes the matching private key straight into your configuration; you never see or paste it.
 
-1. Send Sepolia ETH to that address from a public faucet.
+1. Under **2. LEZ account**, click **Create an account**.
 
-    This is the one part that has to happen outside the app, because only you can fund your Ethereum address. It's the LEZ side, not this one, that the app funds for you in the next two cards, so you can send the Sepolia ETH now or while the LEZ funding runs. You'll need it before you take an offer in [Step 4](#step-4-take-a-live-offer).
+    **Expected:** the section shows `done` and displays **Your account** followed by your new [account](../get-started/glossary.md#account) ID. Nothing is on-chain yet—creating the account is local, and the next section is what puts it on-chain.
 
-    :::info
-    The card shows the address but has no copy button. To copy it exactly, open the **Config** tab and copy **Recipient Address** under **Ethereum**, which the app filled with the same address.
-    :::
+1. Under **3. Fund LEZ**, click **Add funds**.
 
-1. Under **2. LEZ account**, click **Create LEZ account**.
+    **Expected:** the button changes to **Adding funds…** and a status line appears with a live seconds counter. It initialises your account on-chain, then claims `150` LEZ from the [Piñata](../get-started/glossary.md#piñata) faucet—each phase needs a proof-of-work solve and an on-chain commit, and testnet blocks can be a minute or more apart, so the counter keeps moving to show it isn't stuck. When it finishes, the section shows `done` and the status line reads **LEZ funded** with the balance it reached.
 
-    **Expected:** the card shows `done` and displays **Account:** followed by your new [account](../get-started/glossary.md#account) ID. Nothing is on-chain yet—creating the account is local, and the next card is what puts it on-chain.
+1. Under **4. Get test ETH**, copy the address shown under **Send it here** and send Sepolia ETH to it.
 
-1. Under **3. Fund it**, click **Fund my account**.
+    This is the one part that has to happen outside the app, because only you can fund your Ethereum address. The section names a faucet, `https://sepolia-faucet.pk910.de/`, behind a **Copy faucet link** button; Basecamp can't open it for you, so paste it into your browser yourself. Any other public Sepolia faucet works just as well.
 
-    **Expected:** the button changes to **Setting up…** and a status line appears with a live seconds counter. It initialises your account on-chain, then claims `150` LEZ from the [Piñata](../get-started/glossary.md#piñata) faucet—each phase needs a proof-of-work solve and an on-chain commit, and testnet blocks can be a minute or more apart, so the counter keeps moving to show it isn't stuck. When it finishes, the card shows `done`, the status reads **Funded and ready**, and a **4. Done** card appears with a **Go to Market** button.
+    **Expected:** while you wait, the section reads `Watching for it… you don't need to do anything.` and polls for the balance on its own. Once the ETH lands it shows `done` and a line reading **Arrived —** followed by the amount.
+
+1. Under **5. Start trading**, click **Go to Market**.
+
+    The button only enables once both **3. Fund LEZ** and **4. Get test ETH** are done, because a swap needs LEZ to receive and Sepolia ETH to pay gas with.
 
 :::info
-The **Fund my account** button initialises the account for you, so you can't forget to. That matters because an uninitialised LEZ account is the most confusing failure in this app: the sequencer silently discards transactions that reference an account it has never seen initialised, so a swap simply stalls rather than failing. If a swap ever does nothing at all, re-running **Fund my account** re-checks the initialisation.
+The **Add funds** button initialises the account for you, so you can't forget to. That matters because an uninitialised LEZ account is the most confusing failure in this app: the sequencer silently discards transactions that reference an account it has never seen initialised, so a swap simply stalls rather than failing. If a swap ever does nothing at all, re-running **Add funds** re-checks the initialisation.
 :::
 
 ## Step 3: Confirm your configuration
 
-The **Config** tab holds every endpoint, address, and key the app uses, grouped under **Ethereum**, **LEZ**, and **Swap parameters**. After the **Setup** tab, the key fields are already filled and the network values ship pre-filled, so this step is a check rather than a data-entry exercise. You can skip it and still complete a swap; it's here so you can see what **Setup** did and confirm nothing is off.
+**Advanced settings**, at the foot of the **Setup** tab, holds every endpoint, address, and key the app uses, grouped under **Ethereum**, **LEZ**, **Swap Parameters**, and **Developer**. It is the former **Config** tab, folded into **Setup** so there is one place to set the app up rather than two. After the guided sections above it, the key fields are already filled and the network values ship pre-filled, so this step is a check rather than a data-entry exercise. You can skip it and still complete a swap; it's here so you can see what **Setup** did and confirm nothing is off.
 
-1. Open the **Config** tab.
+1. Open the **Setup** tab and expand **Advanced settings**.
 
 1. Under **Ethereum**, confirm **RPC URL** is `wss://ethereum-sepolia-rpc.publicnode.com` and **HTLC Contract Address** is `0x351B0EA07739FA9F6769213927D7836a790A5FAF`.
 
-1. Still under **Ethereum**, confirm **Private Key** and **Recipient Address** are populated. **Setup** filled both from the key it generated in [Step 2](#step-2-set-up-your-accounts). **Recipient Address** is where your bought tokens' counterpart settles, so it's the address belonging to that same key.
+1. Still under **Ethereum**, confirm **Private Key** and **Recipient Address** are populated. The guided sections filled both from the key they generated in [Step 2](#step-2-set-up-your-accounts). **Recipient Address** is where your bought tokens' counterpart settles, so it's the address belonging to that same key.
 
-1. Under **LEZ**, confirm **Sequencer URL** is `https://testnet.lez.logos.co` and **HTLC Program ID** is `27720b5b0345135d8e684eb172c27f5fb237548cc891a3ec889d0ed340504070`.
+1. Under **LEZ**, confirm **Sequencer URL** is `https://testnet.lez.logos.co` and **HTLC Program ID** is `9eb88f51aae87a58fb74b8d2dc7327b39333585e63280e3f9cf8d86dac0ed702`.
 
-1. Still under **LEZ**, confirm **Signing Key** is populated. **Setup** filled it from the LEZ account it created in [Step 2](#step-2-set-up-your-accounts).
+1. Still under **LEZ**, confirm **Signing Key** is populated. The guided sections filled it from the LEZ account they created in [Step 2](#step-2-set-up-your-accounts).
 
-    Leave **Wallet Home**, **Wallet Account ID**, and **Taker Account ID** empty. The app authenticates to the LEZ with the signing key, so the wallet fields aren't needed. **Taker Account ID** is an optional maker-side setting—a list of counterparties you'd allow to take your offers—and taking an offer doesn't need it. **Wallet Home**'s placeholder, `.scaffold/wallet`, is a path from the app's development setup that doesn't exist on a machine that installed from the catalogue.
+    Leave **Wallet Home**, **Wallet Account ID**, and **Sell to one buyer only (optional)** empty. The app authenticates to the LEZ with the signing key, so the wallet fields aren't needed. **Sell to one buyer only (optional)** is a seller-side setting—the one account you'd allow to take your offers—and buying doesn't need it. **Wallet Home**'s placeholder, `.scaffold/wallet`, is a path from the app's development setup that doesn't exist on a machine that installed from the catalogue.
 
-1. Leave **Swap parameters** alone.
+1. Leave **Swap Parameters** alone.
 
-    These set the terms of offers you'd publish as a maker. When you take someone else's offer, the amounts and time locks come from that offer instead.
+    These set the terms of offers you'd publish as a seller. When you take someone else's offer, the amounts and time locks come from that offer instead.
 
-**Expected:** no red text under any field, and the **Market** tab's status chip reads `Config ready`. There's no save button. The app validates and saves as you type, roughly half a second after you stop.
+1. Leave **Developer** alone too.
+
+    Its two buttons load credentials from a `.env` file next to a source checkout, which a catalogue install doesn't have.
+
+**Expected:** no red text under any field, and the **Market** tab's readiness chip reads `Ready to trade`. There's no save button. The app validates and saves as you type.
 
 If a field is wrong, the app says so directly underneath it, with messages like `Required`, `Must be a 20-byte ETH address`, or `Must be a 32-byte hex program ID`. Fix those before continuing, because the app refuses to start a swap while any remain.
 
@@ -178,26 +184,26 @@ Logos runs a maker on this testnet. It publishes offers and waits for someone to
 
 1. Open the **Market** tab.
 
-    **Expected:** a live tape with the columns `OFFER`, `RATE LEZ/ETH`, `MAKER`, `AGE`, and `EXPIRES`. The board rescans every five seconds.
+    **Expected:** a header reading `LIVE MARKET` with a count of the offers on the board, and a live tape with the columns `OFFER`, `RATE LEZ/ETH`, `SELLER`, `AGE`, and `EXPIRES`. A `next scan` bar beside the header drains between scans; the board rescans every two seconds by default.
 
     When our maker is online, it advertises `10 LEZ` for `0.00001 ETH`, and that's the offer the rest of this step follows. The board can also be legitimately empty, because offers are live broadcasts rather than stored listings. If you see no offers, work through [The Market tab is empty](#the-market-tab-is-empty) and come back.
 
 1. Click the offer.
 
-    **Expected:** a detail pane on the right reading **Buy 10 LEZ** `for 0.00001 ETH`, listing the maker's addresses, the hashlock, and both HTLC identifiers. You're buying the LEZ and paying the ETH.
+    **Expected:** a detail pane on the right reading **Buy 10 LEZ** `for 0.00001 ETH`, with the rate beneath it, then both time locks and the rows **Seller ETH address**, **Seller LEZ account**, **Hashlock**, **LEZ program**, and **ETH contract**. You're buying the LEZ and paying the ETH.
 
-1. Click **Accept—buy 10 LEZ**.
+1. Click the button reading `Accept — buy 10 LEZ`.
 
-    If the button is disabled, the app shows why immediately beneath it, such as `Complete configuration first → Config` or `This offer has expired`.
+    If the button is disabled, the app shows why immediately beneath it, such as `Finish setting up first — open Setup`, `This offer has expired`, or a note that you don't hold enough ETH for this offer plus gas.
 
-1. Switch to the **Taker** tab and watch it run.
+1. Switch to the **Swap** tab and watch it run.
 
-    **Expected:** the progress stepper ticks through `Generate Preimage`, `Lock ETH`, `ETH Locked`, `Wait for LEZ Lock`, `LEZ Lock Detected`, `Verify LEZ Escrow`, `LEZ Escrow Verified`, `Claim LEZ`, and `LEZ Claimed`. It usually takes one to three minutes, most of it waiting on Sepolia confirmations.
+    **Expected:** the progress stepper ticks through `Generate your secret`, `Lock your ETH`, `Your ETH is locked`, `Wait for the seller`, `Seller locked their LEZ`, `Check the escrow`, `Escrow checks out`, `Claim your LEZ`, and `LEZ claimed`. It usually takes one to three minutes, most of it waiting on Sepolia confirmations.
 
-1. Click **Refresh** in the header and confirm your `LEZ` balance rose by `10`.
+1. Confirm the `LEZ` balance in the strip beneath the tabs has risen by `10`. It refreshes itself, so there's nothing to click.
 
 :::info
-Offers are live announcements, not stored listings. Nothing retains them, so the **Market** tab can only show what a maker is broadcasting at that moment. The board says as much under the tape: `Offers are advertisements — a swap completes only if the maker is live.`
+Offers are live announcements, not stored listings. Nothing retains them, so the **Market** tab can only show what a maker is broadcasting at that moment. The board says as much under the tape: `Offers are advertisements — a swap completes only if the seller is still online.`
 :::
 
 ## Step 5: Read your receipt and verify it
@@ -208,9 +214,9 @@ Every finished swap writes a receipt recording both legs, so you can check the t
 
     **Expected:** a card headed `SWAP COMPLETED` with the hero line **Bought 10 LEZ**, followed by labelled rows including **Hashlock**, **Preimage**, **ETH lock tx**, **LEZ claim tx**, **ETH HTLC contract**, and both time locks. The preimage stays masked behind a **Reveal** toggle.
 
-1. On the **ETH lock tx** row, click **Copy explorer link**, then paste the link into your browser.
+1. On the **ETH lock tx** row, click the **↗** button, which copies a block-explorer link, then paste that link into your browser.
 
-    **Expected:** the button confirms `Explorer link copied`, and Etherscan shows a successful transaction against the HTLC contract. The URL looks like `https://sepolia.etherscan.io/tx/0x…`.
+    **Expected:** the button becomes a **✓**, and Etherscan shows a successful transaction against the HTLC contract. The URL looks like `https://sepolia.etherscan.io/tx/0x…`.
 
 1. Do the same on the **LEZ claim tx** row.
 
@@ -221,16 +227,16 @@ Every finished swap writes a receipt recording both legs, so you can check the t
     They match, which is the point. The same hash bound both locks, and the preimage now published on the LEZ chain is what released both.
 
 :::warning
-A Basecamp app can't open your browser for you. Logos app interfaces run inside a sandboxed QML engine that silently ignores requests to open an external URL, as reported in [eth-lez-atomic-swaps#84](https://github.com/logos-co/eth-lez-atomic-swaps/issues/84). That's why the receipt offers **Copy value** and **Copy explorer link** buttons instead of clickable links, and why every instruction here says to paste the link into your browser yourself.
+A Basecamp app can't open your browser for you. Logos app interfaces run inside a sandboxed QML engine that silently ignores requests to open an external URL, as reported in [eth-lez-atomic-swaps#84](https://github.com/logos-co/eth-lez-atomic-swaps/issues/84). That's why every row on the receipt carries copy buttons instead of clickable links—**⧉** for the value itself, **↗** for a block-explorer link—and why every instruction here says to paste the link into your browser yourself.
 :::
 
-Two rows are deliberately copy-only, with no explorer link. **ETH swap ID (lock)** is an identifier internal to the contract rather than a transaction hash, and **LEZ HTLC program** names a [program](../get-started/glossary.md#program) rather than a transaction. Keep the swap ID anyway. It's what the **Refund** tab asks for if a later swap stalls.
+Two rows are deliberately copy-only, with no explorer link. **ETH swap ID (lock)** is an identifier internal to the contract rather than a transaction hash, and **LEZ HTLC program** names a [program](../get-started/glossary.md#program) rather than a transaction. Keep the swap ID anyway. It's what the **Refund** tab asks for if you ever have to claim back a swap this install has no record of.
 
 ## Step 6: Send feedback
 
 This app is a testnet preview, and the quickest way to improve it is to report what you hit.
 
-On any receipt, click **Copy feedback link** and paste it into your browser. It opens a pre-structured feedback form on the app repository. Then click **Copy safe evidence** and paste that into the form. It gathers the hashes, addresses, and versions needed to trace your swap on both chains, and it deliberately leaves out your keys and preimage.
+On any receipt, click **Copy feedback link** and paste it into your browser. It opens a pre-structured feedback form on the app repository. Then click **Copy safe evidence** and paste that into the form. It gathers the chain ID, the transaction hashes, and the explorer links needed to trace your swap on both chains, and it deliberately leaves out your keys, your preimage, the hashlock, and your addresses.
 
 If you never got as far as a receipt, [open an issue](https://github.com/logos-co/eth-lez-atomic-swaps/issues/new) describing what you expected and what happened instead, with your platform and the `swap` and `swap_ui` versions from the **Package Manager**.
 
@@ -242,7 +248,7 @@ Restart Basecamp. A newly installed app reaches the sidebar only after a restart
 
 ### The Market tab is empty
 
-Read the empty state, because it names the cause. `Finish network setup to browse` means your configuration isn't valid yet, so the app never subscribed to anything. `Connecting to the swap network…` means the app hasn't found a delivery peer yet, which usually resolves on its own within a minute. `No offers on the board yet` means you're connected and configured, and the maker is simply offline for the moment. Wait a few minutes and let the board rescan. Because nothing retains offers, the tab can only ever show what's being broadcast right now.
+Read the empty state, because it names the cause. `Finish network setup to browse` means your configuration isn't valid yet, so the app never subscribed to anything. `Connecting to the swap network…` means the app hasn't found a delivery peer yet, which usually resolves on its own within a minute. `No offers on the board yet` means you're connected and configured, and the maker is simply offline for the moment. `Connected, but nobody else is` means the opposite problem: you're on the swap network but attached to no peers, so no offer can reach you—it usually clears on its own, and if it doesn't, check for a module update in Basecamp and restart it. Wait a few minutes and let the board rescan. Because nothing retains offers, the tab can only ever show what's being broadcast right now.
 
 ### The app can't connect to Ethereum
 
@@ -250,19 +256,19 @@ Check **RPC URL** begins with `wss://` and not `https://`. The app opens a WebSo
 
 ### The swap does nothing and no error appears
 
-Your LEZ account is almost certainly uninitialised. The sequencer discards transactions for an account it has never seen initialised and returns no error, so the app has nothing to report. Open the **Setup** tab from [Step 2](#step-2-set-up-your-accounts) and click **Fund my account** again—it re-checks the on-chain initialisation and tops the balance back up. Confirm the balance is genuinely positive before retrying.
+Your LEZ account is almost certainly uninitialised. The sequencer discards transactions for an account it has never seen initialised and returns no error, so the app has nothing to report. Open the **Setup** tab from [Step 2](#step-2-set-up-your-accounts) and click **Add funds** under **3. Fund LEZ** again—it re-checks the on-chain initialisation and tops the balance back up. Confirm the balance is genuinely positive before retrying.
 
-### The Taker tab reports `ETH lock rejected`
+### The swap stalls on `Wait for the seller`
 
-The maker refuses a lock that doesn't leave it enough time to respond, and the Ethereum contract enforces its own floor of 300 seconds. Your Ethereum deadline has to sit comfortably beyond the LEZ one, not just after it. This shows up when a swap is started against an offer that's nearly expired, so take a freshly published one. The maker keeps waiting rather than failing, so your **Taker** tab appears to stall.
+The maker refuses a lock that doesn't leave it enough time to respond, and the Ethereum contract enforces its own floor of 300 seconds. Your Ethereum deadline has to sit comfortably beyond the LEZ one, not just after it. This shows up when a swap is started against an offer that's nearly expired, so take a freshly published one. The maker keeps waiting rather than reporting a failure, so your **Swap** tab appears to stall instead of showing an error.
 
 ### There isn't enough LEZ in the account
 
-Open the **Setup** tab from [Step 2](#step-2-set-up-your-accounts) and click **Fund my account** again. Each run claims `150` LEZ from the Piñata faucet, so repeat it until the balance covers what you need.
+Open the **Setup** tab from [Step 2](#step-2-set-up-your-accounts) and click **Add funds** under **3. Fund LEZ** again. Each run claims `150` LEZ from the Piñata faucet, so repeat it until the balance covers what you need.
 
 ### A swap stopped halfway and the funds are still locked
 
-This is the case the time locks exist for, and no funds are at risk. Copy **ETH swap ID (lock)** from the receipt in the **History** tab, open the **Refund** tab, paste it into **Swap ID** under **ETH refund**, and click **Refund ETH** once your deadline has passed. The contract enforces that deadline, so an early attempt fails outright rather than passing silently. Reclaiming returns your ETH in full, less gas.
+This is the case the time locks exist for, and no funds are at risk. Open the **Refund** tab: a **Ready to claim back** card carries the **Hashlock** and **Swap ID** from your most recent swap, already filled in, so click **Get my ETH back** once your deadline has passed. For an older swap, expand **Enter a refund by hand (advanced)**, copy **ETH swap ID (lock)** from its receipt in the **History** tab, and paste it into **Swap ID** under **Get ETH back**. The contract enforces the deadline, so an early attempt fails outright rather than passing silently. Reclaiming returns your ETH in full, less gas.
 
 ## Next steps
 


### PR DESCRIPTION
## Safe to merge — nothing here depends on an unreleased version

Every claim on the page is true of the **published `swap_ui-v0.4.4`**, and
stays true of 0.4.5.

An earlier revision of this branch carried two clauses describing [#157]'s
pre-flight funds guard, which is on `master` but unreleased. Those are cut in
`70c7060`: the prerequisite now says a swap cannot be completed without
Sepolia ETH — true whether the app blocks the attempt (0.4.5) or the attempt
dies on gas (0.4.4) — and the disabled-button list drops the funds reason,
which is fine because that list was already introduced with "such as".

For the record, two things this section previously mis-attributed to 0.4.5:
**0.4.4 already renders five numbered Setup sections** ([#158] only changed
the subtitle string, which this page never quotes), and **Add funds** is
0.4.4. Both were always safe.

[#157]: https://github.com/logos-co/eth-lez-atomic-swaps/pull/157
[#158]: https://github.com/logos-co/eth-lez-atomic-swaps/pull/158

## What and why

`docs/basecamp/swap-eth-and-lez-tokens-in-logos-basecamp.md` is the "Full
walkthrough" the atomic-swap app's README links, so it is the second thing
a public tester reads. It still described 0.4.3. The 0.4.4 release reworked
the app's navigation and rebuilt the guided Setup screen, so most of the
page's UI references no longer matched what a tester actually sees.

Every claim was re-verified against the `eth-lez-atomic-swaps` sources at
`swap_ui-v0.4.4` plus the two commits queued for 0.4.5. Nothing was carried
forward on trust, and nothing I could not verify was changed.

## The changes

**Version numbers are removed, not bumped.** The catalogue always serves the
current release, so pinning a number in prose only guarantees the next
release makes the page wrong again. The page now tells the reader to install
whatever the catalogue offers.

**The tab row.** Seven tabs (`Market`, `Config`, `Maker`, `Taker`, `Refund`,
`History`, `Setup`) became six: `Market`, `Swap`, `History`, then a divider,
then `Sell`, `Refund`, `Setup`. `Config` is now the Setup tab's **Advanced
settings** section, `Maker` is `Sell`, and `Taker` is `Swap`. Step 3 and
every cross-reference follow.

**The Setup screen.** Three numbered cards plus a "4. Done" card are now
five numbered sections — `1. Ethereum key`, `2. LEZ account`, `3. Fund LEZ`,
`4. Get test ETH`, `5. Start trading` — with new button labels (**Generate a
key**, **Create an account**, **Add funds**). Section 4 is new and matters:
the app funds your LEZ but cannot fund Sepolia gas, so it names a faucet and
watches for the ETH to land. The old note saying the address had no copy
button is deleted — it has one now.

**A real bug, not just staleness.** The LEZ HTLC program ID in the "Networks
and addresses" table was `27720b5b…`, the superseded LEZ v0.2.0 value. The
testnet was reset and repinned to v0.2.2 on 2026-08-06, and the app has
compiled in `9eb88f51…` since 0.4.1
(`swap-ffi/src/lez_htlc_program_id.rs`). That table exists so a reader can
*restore* a value they changed by mistake — anyone who did so would have had
their transactions silently discarded by the sequencer, with no error.

**Also corrected:** the Market board's columns and empty states, the Swap
tab's stepper labels, the Refresh button that no longer exists (balances
self-refresh), the receipt's copy controls, the Refund tab's pre-filled
card, and the "Copy safe evidence" description, which claimed the payload
carries addresses and versions it deliberately excludes.

## Deliberately left alone

- **The catalogue URL.** Already the canonical `raw.githubusercontent.com`
  one, and [#158] just made it the single front door in the app repo too.
- **The `Testnet v0.2.1` banner.** A repo-wide convention across 41 docs
  that tracks the Testnet release, not the app this page describes.
- **The Basecamp version prerequisite.** The page states none and still
  states none. swap 0.4.4 is validated against Basecamp 0.2.3
  (`scripts/basecamp-dev.sh`) and 0.2.2 installs it equally well — which is
  not a minimum-version compatibility claim worth writing down.

## Checks

- `npm run build` (Docusaurus) — passes.
- `vale` — 0 errors, same as the pre-change file. Vale gates on
  `error`-level alerts on added lines only; the warnings and suggestions
  that remain also predate this change in kind.

No adjacent page repeats these facts — `grep` over `docs/` finds the swap
app named nowhere else.

`AGENTS.md` is added recording the two local checks and the fact that this
page's subject lives in another repository, so the next session verifies
rather than assumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VrDLGWE1BN2GfvZep4eRjN
