### PR TITLE
docs(basecamp): serve the swap walkthrough at a short URL

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,10 @@ Several pages under `docs/` (notably `docs/basecamp/swap-eth-and-lez-tokens-in-l
 
 For the swap page specifically, ground truth lives in `logos-co/eth-lez-atomic-swaps` at the `swap_ui-vX.Y.Z` tags: `swap-ui/src/qml/SetupSteps.js` derives the Setup step order, titles, numbering and page subtitle for both onboarding flows, `swap-ui/src/qml/SetupView.qml` holds the card copy, and `docs/DEVELOPMENT.md` documents which flow ships by default. Read those at the tag rather than the repo's working tree, since `master` can be ahead of the released catalogue build.
 
+## Public URLs and renames
+
+A page's public URL is its frontmatter `slug`, not its filename, so the two can differ (`docs/basecamp/swap-eth-and-lez-tokens-in-logos-basecamp.md` serves `/basecamp/atomic-swaps-poc`). Some published URLs live outside this repo — spoken in demo videos, embedded in in-app feedback links — and cannot be fixed after the fact. So never change or remove a `slug` or a `redirects` entry in `docusaurus.config.ts` without leaving the old path redirecting; the plugin's redirect page carries the query string and hash across, so deep links to a step survive. Sidebar entries are raw `href` strings in `sidebars.ts` that the build checks against real routes, and redirect stubs are not routes — point them at the slug.
+
 ## Conventions
 
 `CONTRIBUTING.md` is the authority on document types, templates, and the review workflow; read it before adding or restructuring a page. Note the repo-wide `:::tip[Version]` banner that states which Testnet release a page is accurate for — it tracks the Testnet, not the app the page describes.

--- a/docs/basecamp/swap-eth-and-lez-tokens-in-logos-basecamp.md
+++ b/docs/basecamp/swap-eth-and-lez-tokens-in-logos-basecamp.md
@@ -7,7 +7,7 @@ steps_layout: sectioned
 authors: [danisharora099]
 owner: logos
 doc_version: 1
-slug: swap-eth-and-lez-tokens-in-logos-basecamp
+slug: atomic-swaps-poc
 sidebar_position: 3
 ---
 

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -178,6 +178,16 @@ const config: Config = {
             from: '/build-an-app/build-modules/readme',
             to: '/core/build-modules/build-and-run-a-logos-core-module',
           },
+          // Shortened canonical URLs. The page now lives at the short path
+          // (frontmatter `slug`), and the long path it used to own is kept
+          // alive here because it is spoken in a published demo video and
+          // embedded in in-app feedback links. Docusaurus's redirect page
+          // carries the query string and hash across, so deep links to a
+          // named step still land on that step.
+          {
+            from: '/basecamp/swap-eth-and-lez-tokens-in-logos-basecamp',
+            to: '/basecamp/atomic-swaps-poc',
+          },
         ],
       } satisfies PluginClientRedirects.Options,
     ],

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -31,7 +31,7 @@ const sidebars: SidebarsConfig = {
             {
               type: 'link',
               label: 'Swap ETH and LEZ tokens in Logos Basecamp',
-              href: '/basecamp/swap-eth-and-lez-tokens-in-logos-basecamp',
+              href: '/basecamp/atomic-swaps-poc',
             },
           ],
         },


### PR DESCRIPTION
## What

`docs.logos.co/basecamp/swap-eth-and-lez-tokens-in-logos-basecamp` is not a URL anyone can say out loud or type. The atomic swap walkthrough now serves from:

| Route | Result |
| --- | --- |
| `/basecamp/atomic-swaps-poc` | the page (canonical) |
| `/basecamp/swap-eth-and-lez-tokens-in-logos-basecamp` | redirects to it |

## How

- **Frontmatter `slug`** on `docs/basecamp/swap-eth-and-lez-tokens-in-logos-basecamp.md` moves the page to the short route. The file name is unchanged, so the doc ID, the sidebar position and the "Edit this page" link all still resolve.
- **`@docusaurus/plugin-client-redirects`** (already configured in this repo for the legacy GitBook paths) keeps the long path alive. The old URL is spoken in a published demo video and embedded in in-app feedback links, so it can never 404. The plugin's redirect page appends `location.search` and `location.hash`, so a deep link like `…#step-2-set-up-your-accounts` still lands on that step.
- **The sidebar link** in `sidebars.ts` was the only internal reference to the page; it now points at the short route. It has to — sidebar `href`s are checked against real routes under `onBrokenLinks: throw`, and a redirect stub is a `postBuild` file rather than a route. No markdown page cross-links to this doc.

### Why `atomic-swaps-poc` and not `swaps`

"Swap" already means two things in these docs: the cross-chain atomic swap this page covers, and the AMM swaps documented under `lez/` and `build-an-app/`. The `-poc` suffix also marks the app's current status, so the route won't need renaming away from a bare `swaps` once the app is more than a proof of concept.

## Verification

Against the production build (`npm ci && npm run build`, then `docusaurus serve`):

- `/basecamp/atomic-swaps-poc` → `200`, renders the walkthrough.
- `/basecamp/swap-eth-and-lez-tokens-in-logos-basecamp` → `200`, serves the redirect stub pointing at `/basecamp/atomic-swaps-poc` with search and hash carried across.
- `/basecamp` index → `200`.
- Build passes with `onBrokenLinks: 'throw'`.
- `vale docs/basecamp/swap-eth-and-lez-tokens-in-logos-basecamp.md` → 0 errors (CI lints `docs` only, `filter_mode: added`).

`AGENTS.md` gains a short **Public URLs and renames** note so a future change doesn't quietly drop the redirect or repoint the sidebar at a stub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HUebWmDDiZbZDtASYbq9bh