### PR TITLE
docs: follow the delivery module's query-node.md move to docs/pages

### DIFF
--- a/docs/messaging/delivery/run-logos-delivery-node.md
+++ b/docs/messaging/delivery/run-logos-delivery-node.md
@@ -196,7 +196,7 @@ Query the node's discv5 ENR to confirm it booted with a network identity and joi
    logoscore status
    ```
 
-1. Run the [health query](https://github.com/logos-co/logos-delivery-module/blob/master/docs/query-node.md):
+1. Run the [health query](https://github.com/logos-co/logos-delivery-module/blob/master/docs/pages/query-node.md):
 
    ```bash
    # Path A


### PR DESCRIPTION
Requires https://github.com/logos-co/logos-delivery-module/pull/95

# Description

1. Repointed the health-query link at `docs/pages/query-node.md`. `logos-delivery-module` moves its guides under `docs/pages/` in the PR above, and this link is pinned to `master`, so it 404s once that merges — GitHub does not redirect moved files.

Merge after the delivery-module PR, not before: until it lands, the new path does not exist on `master` either.
