### PR TITLE
docs: extension pages follow the upstream framework pin

### DIFF
--- a/docs/lez/extensions/admin-authority.md
+++ b/docs/lez/extensions/admin-authority.md
@@ -16,7 +16,7 @@ sidebar_position: 1
 :::warning
 This page is an early draft and may be incomplete or incorrect. Expect changes, missing prerequisites, and commands that might not work in your setup. This content is still being completed and verified.
 
-This page tracks unreleased code. The dependency snippets pin a personal fork of the framework and pre-release library tags. The pins move to logos-co sources once the extension mechanism lands upstream ([logos-co/spel#257](https://github.com/logos-co/spel/pull/257)).
+This page tracks unreleased code. The dependency snippets pin the framework at an upstream commit, the one that merged the extension mechanism ([logos-co/spel#257](https://github.com/logos-co/spel/pull/257)), and pre-release library tags. The framework pin becomes a release tag once upstream cuts a release that contains it.
 :::
 
 :::tip[Version]
@@ -37,13 +37,13 @@ If your program needs multi-party approval rather than single-admin gating, `adm
 
 ## Prerequisites
 
-You need a stable Rust toolchain, git, and the native build tools the dependency tree leans on. The `spel` CLI additionally needs `unzip` (the `rust-rapidsnark` build script downloads a prebuilt zip and unpacks it through a helper shell script) and the Python development library (a transitive dependency links against libpython through `pyo3`). The verification step at the end uses `jq`. On a fresh Ubuntu 24.04 this covers everything:
+You need a stable Rust toolchain, git, and the native build tools the dependency tree leans on. The `spel` CLI additionally needs `unzip` (the `rust-rapidsnark` build script downloads a prebuilt zip and unpacks it through a helper shell script), the Python development library (a transitive dependency links against libpython through `pyo3`), and the PC/SC smart card library (the wallet crate it builds links `pcsc`). The verification step at the end uses `jq`. On a fresh Ubuntu 24.04 this covers everything:
 
 ```bash
-sudo apt-get update && sudo apt-get install -y curl git build-essential pkg-config libssl-dev ca-certificates unzip python3 python3-dev cmake jq
+sudo apt-get update && sudo apt-get install -y curl git build-essential pkg-config libssl-dev ca-certificates unzip python3 python3-dev cmake libpcsclite-dev jq
 ```
 
-Two different floors apply here, and neither comes from `admin-authority` itself, which declares only `rust-version = "1.88"`. Building your program needs rustc 1.90 or newer whenever `ruint` resolves freely, the floor its 1.20.0 release sets. A `spel init` scaffold pins `ruint = "=1.17.0"` in its guest manifest, so that particular floor does not apply on the scaffold route. Installing the `spel` CLI needs rustc 1.94.0 or newer: a transitive `logos-blockchain` crate uses `strict_overflow_ops`, which older toolchains reject as an unstable feature. The CLI pins `channel = "1.94.0"` in its own `rust-toolchain.toml`, but `cargo install --git` does not apply a dependency's toolchain file, so your default toolchain has to meet that floor itself. Verified on a clean Ubuntu 24.04: the CLI installs on 1.94.0, and the scaffolded program builds on the same toolchain. The lifecycle commands were verified against a live LEZ stack during the library's milestone reviews, on the same framework revision this page pins. The co-signing exchange is the one exception, see the transfer section.
+Two different floors apply here, and neither comes from `admin-authority` itself, which declares only `rust-version = "1.88"`. Building your program needs rustc 1.90 or newer whenever `ruint` resolves freely, the floor its 1.20.0 release sets. A `spel init` scaffold pins `ruint = "=1.17.0"` in its guest manifest, so that particular floor does not apply on the scaffold route. Installing the `spel` CLI needs rustc 1.94.0 or newer: a transitive `logos-blockchain` crate uses `strict_overflow_ops`, which older toolchains reject as an unstable feature. The CLI pins `channel = "1.94.0"` in its own `rust-toolchain.toml`, but `cargo install --git` does not apply a dependency's toolchain file, so your default toolchain has to meet that floor itself. Verified on a clean Ubuntu 24.04 at the previous framework revision and re-run with these pins on 1.94.0: the CLI installs, and the scaffolded program builds on the same toolchain. The lifecycle commands were verified against a live LEZ stack during the library's milestone reviews, at the previous framework revision (`f7aa464`, LEZ v0.2.0). The co-signing exchange is the one exception, see the transfer section.
 
 ## Add the dependency
 
@@ -51,25 +51,25 @@ In your program's `Cargo.toml`. If you do not have a program crate yet, do [Inst
 
 ```toml
 [dependencies]
-admin-authority = { git = "https://github.com/mmlado/spel-admin-authority", tag = "v0.1.2" }
-spel-framework  = { git = "https://github.com/mmlado/spel", rev = "f7aa464b2c6c72ef513a25ede16584bca85b722f" }
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0", package = "lee_core" }
+admin-authority = { git = "https://github.com/mmlado/spel-admin-authority", tag = "v0.1.3" }
+spel-framework  = { git = "https://github.com/logos-co/spel", rev = "8183b011b1a00dbc73ca9209f6b902c622d899af" }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.4", package = "lee_core" }
 borsh = { version = "1", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 ```
 
 All five are needed: the reference samples use exactly this set. `nssa_core` carries the on-chain account types, `borsh` encodes your state, and `serde` is required by the instruction plumbing even when your own types never touch it. The `admin-authority-macros` sub-crate is pulled in transitively. You do not need to declare it directly.
 
-The `spel-framework` entry points at a fork on purpose. It must be the exact revision `admin-authority` itself pins, and the library README documents that revision for each release. Pointing at `logos-co/spel` instead puts two copies of the framework into your dependency graph, and the build fails with a `From<AdminError>` trait error plus name resolution errors inside the `require_admin` expansion. The dependency moves to `logos-co/spel` once the extension mechanism lands upstream ([logos-co/spel#257](https://github.com/logos-co/spel/pull/257)).
+The `spel-framework` entry points at an exact commit on purpose. It must be the revision `admin-authority` itself pins, spelt the same way, and the library README documents that revision for each release. Pointing at a branch instead, or at any other commit, puts two copies of the framework into your dependency graph, and the build fails with a `From<AdminError>` trait error plus name resolution errors inside the `require_admin` expansion. The revision is the upstream commit that merged the extension mechanism ([logos-co/spel#257](https://github.com/logos-co/spel/pull/257)). It becomes a tag once upstream cuts a release that contains it.
 
 After adding the dependencies, run `cargo fetch` once from `methods/guest`, not from the project root. The scaffold's root `Cargo.toml` excludes `methods/guest`, so a root `cargo fetch` resolves a graph that does not contain `admin-authority`: it still updates the workspace's own registry and git sources and exits 0, so nothing in its output tells you the extension was skipped. The framework's extension scanner resolves your dependency graph with an offline metadata call, which fails deterministically for a fresh consumer whose git dependencies were never fetched.
 
 ## Install the `spel` CLI
 
-The lifecycle commands below and the IDL check at the end use the `spel` CLI. Install it from the same fork revision the framework dependency pins:
+The lifecycle commands below and the IDL check at the end use the `spel` CLI. Install it from the same upstream revision the framework dependency pins:
 
 ```bash
-cargo install --git https://github.com/mmlado/spel --rev f7aa464b2c6c72ef513a25ede16584bca85b722f spel
+cargo install --git https://github.com/logos-co/spel --rev 8183b011b1a00dbc73ca9209f6b902c622d899af spel
 ```
 
 The package name is `spel`, not `spel-cli` as the repository directory suggests, asking cargo for `spel-cli` fails with "could not find `spel-cli`."
@@ -82,16 +82,16 @@ curl -fL https://github.com/logos-blockchain/logos-blockchain-circuits/releases/
   | tar xz -C ~/.cache/logos/blockchain/
 ```
 
-The version has to match the `logos-blockchain-circuits` version the pinned framework resolves to, `v0.5.3` for `f7aa464`. The build script reuses any artifact directory it finds there and skips the download entirely.
+The version has to match the `logos-blockchain-circuits` version the pinned framework resolves to, `v0.5.3` for `8183b01`. The build script reuses any artifact directory it finds there and skips the download entirely.
 
 ## Annotate the module
 
-This page assumes you already have an LEZ program crate. A deployable one is a RISC Zero guest, and `spel init` scaffolds it at `methods/guest/src/bin/<name>.rs`, where `<name>` is the project name with hyphens replaced by underscores, so `spel init my-program` writes `my_program.rs`. That is the same layout `spel generate-idl` auto-detects when given no path. Pass both source flags ahead of the project name, the parser stops reading flags at the first argument that is not one, so anything after the name is dropped without a warning. With the default pins the scaffold takes `logos-co/spel` `main`, whose framework has no extension scanner and whose `lee_core` does not match the one `admin-authority` pins, and the guest then fails to compile with type errors out of the `#[lez_program]` expansion rather than anything naming the marker:
+This page assumes you already have an LEZ program crate. A deployable one is a RISC Zero guest, and `spel init` scaffolds it at `methods/guest/src/bin/<name>.rs`, where `<name>` is the project name with hyphens replaced by underscores, so `spel init my-program` writes `my_program.rs`. That is the same layout `spel generate-idl` auto-detects when given no path. Pass both source flags ahead of the project name, the parser stops reading flags at the first argument that is not one, so anything after the name is dropped without a warning. With the default pins the scaffold takes `logos-co/spel` at a floating reference, a pull request head at this revision of the CLI. A floating pin never unifies with the exact revision `admin-authority` pins, and as it moves its `lee_core` can differ too. Either way the guest ends up with two copies of the framework and fails to compile with type errors out of the `#[lez_program]` expansion rather than anything naming the marker. Pass the revision:
 
 ```bash
 spel init \
-    --spel-git https://github.com/mmlado/spel.git \
-    --spel-rev f7aa464b2c6c72ef513a25ede16584bca85b722f \
+    --spel-git https://github.com/logos-co/spel.git \
+    --spel-rev 8183b011b1a00dbc73ca9209f6b902c622d899af \
     my-program
 ```
 
@@ -219,7 +219,7 @@ spel --idl program-idl.json --program <program-id> -- \
     --candidate Signer
 ```
 
-A `Signer` transfer needs the new admin's signature on the same transaction, which proves the keyholder consents. That means two parties sign one message. The `spel` CLI at the pinned revision has no co-signing exchange: the command above builds and submits with the caller's signature only, and the sequencer drops the transaction unless the candidate's signature is attached. Collecting that second signature is not possible from the pinned `spel`. The exchange flow merged upstream after this revision ([logos-co/spel#246](https://github.com/logos-co/spel/pull/246)) and arrives here when the framework pin moves.
+A `Signer` transfer needs the new admin's signature on the same transaction, which proves the keyholder consents. That means two parties sign one message. Run as written, the command above builds and submits with the caller's signature only, and the sequencer drops the transaction unless the candidate's signature is attached. The `spel` CLI at this revision collects that second signature through a partial-transaction file ([logos-co/spel#246](https://github.com/logos-co/spel/pull/246)): the current admin adds the global flags `--co-signer <new-admin-account-id> --export handover.json` before the `--` separator, which writes the transaction to the file instead of submitting it. The new admin runs `spel sign handover.json` on their own machine, offline, and anyone with a node connection then runs `spel submit handover.json`. The CLI README's witness exchange section describes the file format. This page has not walked that exchange against a live stack.
 
 After the transaction lands, the previous admin can no longer call gated instructions.
 
@@ -316,12 +316,12 @@ Expected output includes:
 "admin_renounce"
 ```
 
-Plus your own instructions. On a framework build that carries the extension scanner, a marker that matches no discoverable extension is a hard compile error naming the marker, so a broken setup refuses loudly rather than building without the trio. That safety net is a property of the pinned framework revision: on a framework without the scanner, upstream `logos-co/spel` main today, the marker is ignored and the program builds cleanly without the trio. When you hit the hard error, the most common causes are:
+Plus your own instructions. On a framework build that carries the extension scanner, a marker that matches no discoverable extension is a hard compile error naming the marker, so a broken setup refuses loudly rather than building without the trio. That safety net is a property of the framework revision: on a framework without the scanner, any upstream release from before #257, the marker is ignored and the program builds cleanly without the trio. When you hit the hard error, the most common causes are:
 
 - `admin-authority` not declared as a direct path or git dependency in your `Cargo.toml`. Transitive dependencies are never discovered.
 - Cached macro expansion, run `cargo clean -p <your-crate>` and rebuild.
 
-Misplacing the marker is a different failure and never reaches that error, because a marker above `#[lez_program]` is consumed before the framework sees it. Since nothing on this page imports `admin_authority`, writing it above `#[lez_program]` stops at name resolution instead, with ``cannot find attribute `admin_authority` in this scope`` and a note that the name is a crate rather than an attribute. Import the name and `admin-authority` v0.1.2 rejects the placement itself: `#[admin_authority] must come after #[lez_program]`.
+Misplacing the marker is a different failure and never reaches that error, because a marker above `#[lez_program]` is consumed before the framework sees it. Since nothing on this page imports `admin_authority`, writing it above `#[lez_program]` stops at name resolution instead, with ``cannot find attribute `admin_authority` in this scope`` and a note that the name is a crate rather than an attribute. Import the name and `admin-authority` v0.1.3 rejects the placement itself: `#[admin_authority] must come after #[lez_program]`.
 
 ## Security notes
 

--- a/docs/lez/extensions/build-a-spel-extension-library.md
+++ b/docs/lez/extensions/build-a-spel-extension-library.md
@@ -16,7 +16,7 @@ sidebar_position: 3
 :::warning
 This page is an early draft and may be incomplete or incorrect. Expect changes, missing prerequisites, and commands that might not work in your setup. This content is still being completed and verified.
 
-This page tracks unreleased code. The dependency snippets pin a personal fork of the framework. The pin moves to logos-co sources once the extension mechanism lands upstream ([logos-co/spel#257](https://github.com/logos-co/spel/pull/257)).
+This page tracks unreleased code. The dependency snippets pin the framework at an upstream commit, the one that merged the extension mechanism ([logos-co/spel#257](https://github.com/logos-co/spel/pull/257)). The pin becomes a release tag once upstream cuts a release that contains it.
 :::
 
 :::tip[Version]
@@ -68,7 +68,7 @@ extension_attr = "my_extension"
 
 [dependencies]
 borsh = { version = "1", features = ["derive"] }
-spel-framework = { git = "https://github.com/mmlado/spel", rev = "f7aa464b2c6c72ef513a25ede16584bca85b722f" }
+spel-framework = { git = "https://github.com/logos-co/spel", rev = "8183b011b1a00dbc73ca9209f6b902c622d899af" }
 my-extension-macros = { path = "../my-extension-macros" }
 ```
 
@@ -211,7 +211,7 @@ Never read or strip `#[account(...)]` attributes in a gate macro. That attribute
 
 ```toml
 [dev-dependencies]
-spel-framework-core = { git = "https://github.com/mmlado/spel", rev = "f7aa464b2c6c72ef513a25ede16584bca85b722f", features = ["idl-gen"] }
+spel-framework-core = { git = "https://github.com/logos-co/spel", rev = "8183b011b1a00dbc73ca9209f6b902c622d899af", features = ["idl-gen"] }
 ```
 
 To spare consumers declaring your gate's account parameters on every gated instruction, declare them in your `Cargo.toml`:
@@ -305,7 +305,7 @@ A body-inject gate that references parameters by name only, the way `#[require_a
 
 Some extensions naturally build on others. `freeze-authority` depends on `admin-authority`, its freeze-authority slot is governed by admin signatures. When your extension does this:
 
-1. **Declare a normal Cargo dependency** on the other extension in your `Cargo.toml`, path or git. `freeze-authority` uses a git dependency on `admin-authority` pinned to its `v0.1.2` tag. Consumers get both extensions in their dependency graph automatically.
+1. **Declare a normal Cargo dependency** on the other extension in your `Cargo.toml`, path or git. `freeze-authority` uses a git dependency on `admin-authority` pinned to its `v0.1.3` tag. Consumers get both extensions in their dependency graph automatically.
 2. **Add both markers to the consumer's mod.** Consumers write `#[admin_authority] #[my_extension]` on their `#[lez_program]` mod. Each marker triggers its own discovery.
 3. **Import the gate attributes you compose with.** For example, `use admin_authority::require_admin;` in your library source, then `#[require_admin]` on instructions that should require an admin signature (like an initialisation that creates your config PDA).
 4. **List the other extension's exempt-while-wrapped instructions** in your `wrap_instructions.exempt` if applicable. freeze-authority lists admin-authority's three management instructions so they stay callable while the program is frozen.
@@ -319,14 +319,14 @@ A consumer adds your extension to their `Cargo.toml`:
 ```toml
 [dependencies]
 my-extension = { git = "https://github.com/you/my-extension" }
-spel-framework = { git = "https://github.com/mmlado/spel", rev = "f7aa464b2c6c72ef513a25ede16584bca85b722f" }
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0", package = "lee_core" }
+spel-framework = { git = "https://github.com/logos-co/spel", rev = "8183b011b1a00dbc73ca9209f6b902c622d899af" }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.4", package = "lee_core" }
 serde = { version = "1", features = ["derive"] }
 ```
 
 `nssa_core` and `serde` are named directly by `#[lez_program]`'s expansion, so the consumer must declare both even though their own source never mentions either.
 
-The `spel-framework` pin must be a revision that carries the extension scanner, and it must be the exact revision your library pins, spelt the same way. Upstream `logos-co/spel` does not have the scanner until [logos-co/spel#257](https://github.com/logos-co/spel/pull/257) lands, and a branch reference fails to unify with a rev pin even at the same commit, cargo keys git sources by reference kind. Swap this for the `logos-co` URL once the mechanism reaches an upstream release.
+The `spel-framework` pin must be a revision that carries the extension scanner, and it must be the exact revision your library pins, spelt the same way. Upstream `logos-co/spel` carries the scanner since [logos-co/spel#257](https://github.com/logos-co/spel/pull/257), the revision above is that merge commit, and a branch reference fails to unify with a rev pin even at the same commit, cargo keys git sources by reference kind. The revision becomes a tag once upstream cuts a release that contains it.
 
 Path, git, and registry dependencies are all discoverable. Discovery is restricted to the consumer's direct dependencies, a transitive crate can never contribute instructions by claiming a matching `extension_attr`, and the generated call paths use your `[package].name`, never a directory name.
 

--- a/docs/lez/extensions/freeze-authority.md
+++ b/docs/lez/extensions/freeze-authority.md
@@ -16,7 +16,7 @@ sidebar_position: 2
 :::warning
 This page is an early draft and may be incomplete or incorrect. Expect changes, missing prerequisites, and commands that might not work in your setup. This content is still being completed and verified.
 
-This page tracks unreleased code. The dependency snippets pin a personal fork of the framework and pre-release library tags. The pins move to logos-co sources once the extension mechanism lands upstream ([logos-co/spel#257](https://github.com/logos-co/spel/pull/257)).
+This page tracks unreleased code. The dependency snippets pin the framework at an upstream commit, the one that merged the extension mechanism ([logos-co/spel#257](https://github.com/logos-co/spel/pull/257)), and pre-release library tags. The framework pin becomes a release tag once upstream cuts a release that contains it.
 :::
 
 :::tip[Version]
@@ -41,7 +41,7 @@ If your program needs a permanent pause with no recovery, use `admin_renounce` a
 
 Same toolchain as the admin-authority page: a stable Rust toolchain, git, the native build packages, and the `spel` CLI. See [Prerequisites](admin-authority.md#prerequisites) and [Install the `spel` CLI](admin-authority.md#install-the-spel-cli) there, plus the `spel init` command in [Annotate the module](admin-authority.md#annotate-the-module) if you do not have a program crate yet. Those three are all you need from that page. You do not have to work through the admin integration first: the dependency block below already carries `admin-authority`, and its three instructions arrive with your build. Everything below assumes the toolchain and the CLI are in place.
 
-The build and IDL verification steps on this page were verified on a clean Ubuntu 24.04, in auto, manual, and embedded mode. The toolchain floors from the admin-authority page apply here unchanged. The lifecycle commands were verified against a live LEZ stack during the library's milestone reviews, on the same framework revision this page pins. The multi-signature exchange is the one exception, see the transfer section.
+The build and IDL verification steps on this page were verified on a clean Ubuntu 24.04 at the previous framework revision, in auto, manual, and embedded mode, and the library's own CI builds its three reference samples with these pins in every mode. The toolchain floors from the admin-authority page apply here unchanged. The lifecycle commands were verified against a live LEZ stack during the library's milestone reviews, at the previous framework revision (`f7aa464`, LEZ v0.2.0). The multi-signature exchange is the one exception, see the transfer section.
 
 ## Add the dependency
 
@@ -49,15 +49,15 @@ In your program's `Cargo.toml`. If you do not have a program crate yet, run the 
 
 ```toml
 [dependencies]
-admin-authority  = { git = "https://github.com/mmlado/spel-admin-authority", tag = "v0.1.2" }
-freeze-authority = { git = "https://github.com/mmlado/spel-freeze-authority", tag = "v0.1.3" }
-spel-framework   = { git = "https://github.com/mmlado/spel", rev = "f7aa464b2c6c72ef513a25ede16584bca85b722f" }
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0", package = "lee_core" }
+admin-authority  = { git = "https://github.com/mmlado/spel-admin-authority", tag = "v0.1.3" }
+freeze-authority = { git = "https://github.com/mmlado/spel-freeze-authority", tag = "v0.1.4" }
+spel-framework   = { git = "https://github.com/logos-co/spel", rev = "8183b011b1a00dbc73ca9209f6b902c622d899af" }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.4", package = "lee_core" }
 borsh = { version = "1", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 ```
 
-The `admin-authority` dependency is required because freeze-authority composes with it, and both must be direct dependencies, the framework never discovers extensions transitively. Use the tags above together, `freeze-authority` v0.1.3 pins `admin-authority` v0.1.2, so a consumer on both resolves one copy of each. The framework must be the exact revision those releases pin, spelt as `rev = ...`. A branch reference fails even when the branch points at the same commit, because cargo treats different git reference kinds as different sources and you end up with two copies of the framework and a `From<AdminError>` trait error. The source flips to `logos-co/spel` once the extension mechanism reaches an upstream release ([logos-co/spel#257](https://github.com/logos-co/spel/pull/257)). `nssa_core` carries the on-chain account types, `borsh` encodes your state, and `serde` is required by the instruction plumbing. The `freeze-authority-macros` sub-crate is pulled in transitively.
+The `admin-authority` dependency is required because freeze-authority composes with it, and both must be direct dependencies, the framework never discovers extensions transitively. Use the tags above together, `freeze-authority` v0.1.4 pins `admin-authority` v0.1.3, so a consumer on both resolves one copy of each. The framework must be the exact revision those releases pin, spelt as `rev = ...`. A branch reference fails even when the branch points at the same commit, because cargo treats different git reference kinds as different sources and you end up with two copies of the framework and a `From<AdminError>` trait error. The revision is the upstream commit that merged the extension mechanism ([logos-co/spel#257](https://github.com/logos-co/spel/pull/257)). It becomes a tag once upstream cuts a release that contains it. `nssa_core` carries the on-chain account types, `borsh` encodes your state, and `serde` is required by the instruction plumbing. The `freeze-authority-macros` sub-crate is pulled in transitively.
 
 After adding the dependencies, run `cargo fetch` once from `methods/guest`, not from the project root. The scaffold's root `Cargo.toml` excludes `methods/guest`, so a root `cargo fetch` resolves a graph that contains neither `admin-authority` nor `freeze-authority`: it still updates the workspace's own registry and git sources and exits 0, so nothing in its output tells you the extensions were skipped. The framework's extension scanner resolves your dependency graph with an offline metadata call, which fails deterministically for a fresh consumer whose git dependencies were never fetched. And if you started from `cargo new`, delete the default `fn main`, the `#[lez_program]` macro generates the program's entry point.
 
@@ -223,7 +223,7 @@ spel --idl program-idl.json --program <program-id> -- \
     --candidate Signer
 ```
 
-A `Signer` candidate is validated on chain by checking that the new holder co-signed the transaction, and the wallet only collects signatures for declared signer accounts. The `spel` CLI at the pinned revision has no multi-signature exchange flow: the single command above builds and submits with the caller's signature only, and the sequencer drops it unless the new holder's signature is attached. Collecting that second signature is not possible from the pinned `spel`. The exchange flow merged upstream after this revision ([logos-co/spel#246](https://github.com/logos-co/spel/pull/246)) and arrives here when the framework pin moves.
+A `Signer` candidate is validated on chain by checking that the new holder co-signed the transaction, and the wallet only collects signatures for declared signer accounts. Run as written, the command above builds and submits with the caller's signature only, and the sequencer drops it unless the new holder's signature is attached. The `spel` CLI at this revision collects that second signature through a partial-transaction file ([logos-co/spel#246](https://github.com/logos-co/spel/pull/246)): the admin adds the global flags `--co-signer <new-freeze-authority-account-id> --export handover.json` before the `--` separator, the new holder runs `spel sign handover.json` on their own machine, and anyone with a node connection runs `spel submit handover.json`. See the transfer section of the [admin-authority page](admin-authority.md#transfer-admin-to-another-party) for the same flow. This page has not walked that exchange against a live stack.
 
 ## Use a program (PDA) as freeze authority
 


### PR DESCRIPTION
Follow-up to #355, as promised there: logos-co/spel#257 merged on 2026-09-11 and the three libraries released on that commit (spel-authority v0.1.1, admin-authority v0.1.3, freeze-authority v0.1.4). The pages move with them: framework at logos-co/spel 8183b01, the two library tags, lee_core v0.2.4. No fork reference remains. The framework pin stays a rev until upstream cuts a release that contains #257, then it becomes a tag.

Every sentence tied to the old revision was re-checked at the new one:

- The CLI now links pcsc through LEZ's wallet crate, so libpcsclite-dev is a prerequisite. The documented cargo install command was run at this revision on 1.94.0.
- The circuits artifact is still v0.5.3, both LEZ tags pin the same lbc-*-sys release.
- spel init defaults to a floating pull request head, not main. The scaffold path was walked with the page's source flags: pins match, fetch, marker, host check and IDL trio all pass.
- The witness exchange (#246) is in this revision. Both transfer sections describe the co-signer flow from the CLI README and say the page has not walked it live.
- The verification sentences now name the revision each claim was checked on.

Docusaurus build green. Vale runs in CI.

